### PR TITLE
Add tool submission endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,5 +1,5 @@
 # 🚀 **ToolCenter API v1**  
-⏱️ **Date de dernière modification : 24/05/2025**
+⏱️ **Date de dernière modification : 04/06/2025**
 
 API **ultra‑rapide** en **Go** 🐹 pour gérer tes **utilisateurs**, tes **outils** et tout le bazar autour (auth, réservations, stats, etc.).
 
@@ -114,6 +114,31 @@ Réponse :
         "favorites": 4
     },
     "role": "User"
+} 
+```
+
+### Publier un tool ↦ `/api/tools`
+
+Envoi d'un tool (form‑data).
+
+```bash
+curl -X POST https://api.tool-center.fr/api/tools \
+    -H "Authorization: Bearer <token>" \
+    -F "title=Mon super tool" \
+    -F "description=C'est trop cool" \
+    -F "category=development" \
+    -F "url=https://example.com" \
+    -F "tags=cli,open-source" \
+    -F "image=@/chemin/image.png"
+```
+
+Réponse :
+
+```json
+{
+    "success": true,
+    "tool_id": 123,
+    "image_url": "https://tool-center.fr/tool_images/abcd.webp"
 }
 ```
 

--- a/api/main.go
+++ b/api/main.go
@@ -118,6 +118,7 @@ func setupRoutes(r *gin.Engine) {
 	userGroup.POST("/avatar", user.UploadAvatar)
 
 	toolsGroup := api.Group("/tools")
+	toolsGroup.POST("/", tools.SubmitToolHandler)
 	toolsGroup.GET("/me", tools.MyToolsHandler)
 
 	utilsGroup := api.Group("/utils")

--- a/api/scripts/tools/submit_tool.go
+++ b/api/scripts/tools/submit_tool.go
@@ -1,0 +1,155 @@
+package tools
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"toolcenter/config"
+	"toolcenter/utils"
+
+	"github.com/chai2010/webp"
+	"github.com/disintegration/imaging"
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+const toolImageDir = "/var/www/toolcenter/storage/tool_images"
+const toolImageRelPath = "/tool_images/"
+
+func rnd() string {
+	b := make([]byte, 16)
+	_, _ = io.ReadFull(rand.Reader, b)
+	return hex.EncodeToString(b)
+}
+
+func SubmitToolHandler(c *gin.Context) {
+	uid, _, _, err := utils.Check(c, utils.CheckOpts{
+		RequireToken:     true,
+		RequireVerified:  true,
+		RequireNotBanned: true,
+	})
+	if err != nil {
+		code := http.StatusInternalServerError
+		switch err {
+		case utils.ErrMissingToken, utils.ErrInvalidToken, utils.ErrExpiredToken:
+			code = http.StatusUnauthorized
+		case utils.ErrEmailNotVerified, utils.ErrAccountBanned:
+			code = http.StatusForbidden
+		}
+		c.JSON(code, gin.H{"success": false, "message": err.Error()})
+		return
+	}
+
+	title := c.PostForm("title")
+	desc := c.PostForm("description")
+	category := c.PostForm("category")
+	url := c.PostForm("url")
+	tagsRaw := c.PostForm("tags")
+
+	if title == "" || desc == "" || category == "" || url == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "champs manquants"})
+		return
+	}
+
+	var imageRel string
+	if file, header, err := c.Request.FormFile("image"); err == nil {
+		defer file.Close()
+		ext := strings.ToLower(filepath.Ext(header.Filename))
+		if ext != ".jpg" && ext != ".jpeg" && ext != ".png" && ext != ".webp" {
+			c.JSON(http.StatusUnsupportedMediaType, gin.H{"success": false, "message": "format non supporté"})
+			return
+		}
+		tmp := filepath.Join(os.TempDir(), rnd()+ext)
+		out, err := os.Create(tmp)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+			return
+		}
+		if _, err = io.Copy(out, file); err != nil {
+			out.Close()
+			os.Remove(tmp)
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+			return
+		}
+		out.Close()
+		img, err := imaging.Open(tmp)
+		os.Remove(tmp)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "image invalide"})
+			return
+		}
+		img = imaging.Fill(img, 1200, 630, imaging.Center, imaging.Lanczos)
+		_ = os.MkdirAll(toolImageDir, 0755)
+		filename := rnd() + ".webp"
+		final := filepath.Join(toolImageDir, filename)
+		fp, err := os.Create(final)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+			return
+		}
+		if err = webp.Encode(fp, img, &webp.Options{Lossless: true}); err != nil {
+			fp.Close()
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+			return
+		}
+		fp.Close()
+		imageRel = toolImageRelPath + filename
+	}
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "message": "Erreur DB."})
+		return
+	}
+	defer db.Close()
+
+	res, err := db.Exec(`INSERT INTO tools (user_id, title, description, content_url, thumbnail_url, status) VALUES (?, ?, ?, ?, ?, 'Moderated')`,
+		uid, title, desc, url, imageRel)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "message": "Erreur DB."})
+		return
+	}
+	toolID64, _ := res.LastInsertId()
+
+	tags := []string{category}
+	if tagsRaw != "" {
+		for _, t := range strings.Split(tagsRaw, ",") {
+			if tt := strings.TrimSpace(t); tt != "" {
+				tags = append(tags, tt)
+			}
+		}
+	}
+	for _, tag := range tags {
+		var tagID int
+		err := db.QueryRow(`SELECT tag_id FROM tags WHERE name = ?`, tag).Scan(&tagID)
+		if err == sql.ErrNoRows {
+			r, err2 := db.Exec(`INSERT INTO tags (name) VALUES (?)`, tag)
+			if err2 != nil {
+				continue
+			}
+			id, _ := r.LastInsertId()
+			tagID = int(id)
+		} else if err != nil {
+			continue
+		}
+		_, _ = db.Exec(`INSERT INTO tool_tags (tool_id, tag_id) VALUES (?, ?)`, toolID64, tagID)
+	}
+
+	base := config.Get().URLweb
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"tool_id": toolID64,
+		"image_url": func() string {
+			if imageRel != "" {
+				return base + imageRel
+			}
+			return ""
+		}(),
+	})
+}


### PR DESCRIPTION
## Summary
- add POST /tools endpoint to submit a tool
- wire new endpoint in main router
- document tool submission in API README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68408bf2bab48320b1a53033e95c75ca