### PR TITLE
Add logout and account deletion handlers

### DIFF
--- a/api/CONFIG DB ACTUELLE V6.sql
+++ b/api/CONFIG DB ACTUELLE V6.sql
@@ -69,7 +69,7 @@ CREATE TABLE tags (
 ) ENGINE = InnoDB;
 
 CREATE TABLE tools (
-  tool_id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  tool_id CHAR(36) PRIMARY KEY,
   user_id CHAR(36) NOT NULL,
   title VARCHAR(100),
   description TEXT,
@@ -83,7 +83,7 @@ CREATE TABLE tools (
 ) ENGINE = InnoDB ROW_FORMAT = COMPRESSED;
 
 CREATE TABLE tool_tags (
-  tool_id INT UNSIGNED NOT NULL,
+  tool_id CHAR(36) NOT NULL,
   tag_id  INT UNSIGNED NOT NULL,
   PRIMARY KEY (tool_id, tag_id),
   FOREIGN KEY (tool_id) REFERENCES tools (tool_id) ON DELETE CASCADE,
@@ -92,7 +92,7 @@ CREATE TABLE tool_tags (
 
 CREATE TABLE tool_versions (
   version_id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  tool_id INT UNSIGNED NOT NULL,
+  tool_id CHAR(36) NOT NULL,
   title VARCHAR(100),
   description TEXT,
   content_url VARCHAR(255),
@@ -104,7 +104,7 @@ CREATE TABLE tool_versions (
 -- ========= SOCIAL =========
 CREATE TABLE comments (
   comment_id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  tool_id INT UNSIGNED NOT NULL,
+  tool_id CHAR(36) NOT NULL,
   user_id CHAR(36) NOT NULL,
   parent_comment_id INT UNSIGNED,
   content TEXT,
@@ -119,7 +119,7 @@ CREATE TABLE comments (
 
 CREATE TABLE favorites (
   favorite_id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  tool_id INT UNSIGNED NOT NULL,
+  tool_id CHAR(36) NOT NULL,
   user_id CHAR(36) NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   UNIQUE (tool_id, user_id),
@@ -130,7 +130,7 @@ CREATE TABLE favorites (
 
 CREATE TABLE likes (
   like_id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  tool_id INT UNSIGNED NOT NULL,
+  tool_id CHAR(36) NOT NULL,
   user_id CHAR(36) NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   UNIQUE (tool_id, user_id),

--- a/api/main.go
+++ b/api/main.go
@@ -111,15 +111,18 @@ func setupRoutes(r *gin.Engine) {
 	authGroup := api.Group("/auth")
 	authGroup.POST("/login", auth.LoginHandler)
 	authGroup.POST("/register", auth.RegisterHandler)
+	authGroup.POST("/logout", auth.LogoutHandler)
 
 	userGroup := api.Group("/user")
 	userGroup.GET("/verify_email", user.VerifyEmailHandler)
 	userGroup.GET(("/me"), user.MeHandler)
 	userGroup.POST("/avatar", user.UploadAvatar)
+	userGroup.POST("/delete", user.DeleteAccountHandler)
 
 	toolsGroup := api.Group("/tools")
 	toolsGroup.POST("/add", tools.SubmitToolHandler)
 	toolsGroup.GET("/me", tools.MyToolsHandler)
+	toolsGroup.DELETE("/:id", tools.DeleteToolHandler)
 
 	utilsGroup := api.Group("/utils")
 	utilsGroup.POST("/privates_news", utils.PrivateNewsHandler)

--- a/api/scripts/auth/logout.go
+++ b/api/scripts/auth/logout.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+
+	"toolcenter/config"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func LogoutHandler(c *gin.Context) {
+	header := c.GetHeader("Authorization")
+	if len(header) < 8 || header[:7] != "Bearer " {
+		c.JSON(http.StatusUnauthorized, gin.H{"success": false, "message": "Token manquant"})
+		return
+	}
+	raw := header[7:]
+	sum := sha256.Sum256([]byte(raw))
+	tokenHash := hex.EncodeToString(sum[:])
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`DELETE FROM user_tokens WHERE token = ?`, tokenHash)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/api/scripts/tools/delete_tool.go
+++ b/api/scripts/tools/delete_tool.go
@@ -1,0 +1,55 @@
+package tools
+
+import (
+	"net/http"
+
+	"toolcenter/config"
+	"toolcenter/utils"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func DeleteToolHandler(c *gin.Context) {
+	uid, _, _, err := utils.Check(c, utils.CheckOpts{
+		RequireToken:     true,
+		RequireVerified:  true,
+		RequireNotBanned: true,
+	})
+	if err != nil {
+		code := http.StatusInternalServerError
+		switch err {
+		case utils.ErrMissingToken, utils.ErrInvalidToken, utils.ErrExpiredToken:
+			code = http.StatusUnauthorized
+		case utils.ErrEmailNotVerified, utils.ErrAccountBanned:
+			code = http.StatusForbidden
+		}
+		c.JSON(code, gin.H{"success": false, "message": err.Error()})
+		return
+	}
+
+	toolID := c.Param("id")
+	if toolID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "ID manquant"})
+		return
+	}
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	res, err := db.Exec(`DELETE FROM tools WHERE tool_id = ? AND user_id = ?`, toolID, uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	count, _ := res.RowsAffected()
+	if count == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"success": false, "message": "Outil introuvable"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/api/scripts/tools/my_tools.go
+++ b/api/scripts/tools/my_tools.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Tool struct {
-	ID           int       `json:"tool_id"`
+	ID           string    `json:"tool_id"`
 	UserID       string    `json:"user_id"`
 	Title        string    `json:"title"`
 	Description  string    `json:"description"`

--- a/api/scripts/user/delete_account.go
+++ b/api/scripts/user/delete_account.go
@@ -1,0 +1,68 @@
+package user
+
+import (
+	"net/http"
+
+	"toolcenter/config"
+	"toolcenter/utils"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type deleteAccountRequest struct {
+	Password string `json:"password"`
+}
+
+func DeleteAccountHandler(c *gin.Context) {
+	uid, _, _, err := utils.Check(c, utils.CheckOpts{
+		RequireToken:     true,
+		RequireVerified:  true,
+		RequireNotBanned: true,
+	})
+	if err != nil {
+		code := http.StatusInternalServerError
+		switch err {
+		case utils.ErrMissingToken, utils.ErrInvalidToken, utils.ErrExpiredToken:
+			code = http.StatusUnauthorized
+		case utils.ErrEmailNotVerified, utils.ErrAccountBanned:
+			code = http.StatusForbidden
+		}
+		c.JSON(code, gin.H{"success": false, "message": err.Error()})
+		return
+	}
+
+	var req deleteAccountRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.Password == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "Mot de passe requis"})
+		return
+	}
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	var hash string
+	err = db.QueryRow(`SELECT password_hash FROM users WHERE user_id = ?`, uid).Scan(&hash)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	if bcrypt.CompareHashAndPassword([]byte(hash), []byte(req.Password)) != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"success": false, "message": "Mot de passe incorrect"})
+		return
+	}
+
+	_, err = db.Exec(`DELETE FROM users WHERE user_id = ?`, uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}


### PR DESCRIPTION
## Summary
- allow UUID v7 for tool creation
- list tool IDs as strings
- delete own tool
- logout by clearing user token
- remove account with password verification
- update schema to use UUIDs for tools

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684436a516888320bb9cabf36849141e