### PR TITLE
Fix captcha handling in login and signup

### DIFF
--- a/api/scripts/auth/login.go
+++ b/api/scripts/auth/login.go
@@ -22,10 +22,25 @@ type LoginRequest struct {
 	TurnstileToken string `json:"turnstile_token"`
 }
 
+const missingCaptchaMsg = "Captcha manquant."
+
 func LoginHandler(c *gin.Context) {
 	var req LoginRequest
-	if err := c.ShouldBindJSON(&req); err != nil ||
-		req.Email == "" || req.Password == "" || req.TurnstileToken == "" {
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"message": "Requête invalide.",
+		})
+		return
+	}
+	if req.TurnstileToken == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"message": missingCaptchaMsg,
+		})
+		return
+	}
+	if req.Email == "" || req.Password == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,
 			"message": "Requête invalide.",

--- a/api/scripts/auth/register.go
+++ b/api/scripts/auth/register.go
@@ -26,6 +26,8 @@ type RegisterRequest struct {
 	TurnstileToken string `json:"turnstile_token"`
 }
 
+const missingCaptchaMsg = "Captcha manquant."
+
 func validUsername(u string) bool {
 	return len(u) >= 3 && len(u) <= 50 && !strings.ContainsAny(u, " ")
 }
@@ -47,8 +49,12 @@ func hashToken(t string) string {
 
 func RegisterHandler(c *gin.Context) {
 	var req RegisterRequest
-	if err := c.ShouldBindJSON(&req); err != nil || req.TurnstileToken == "" {
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "Requête invalide."})
+		return
+	}
+	if req.TurnstileToken == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": missingCaptchaMsg})
 		return
 	}
 

--- a/frontend/ressources/JS/signin.js
+++ b/frontend/ressources/JS/signin.js
@@ -30,6 +30,7 @@ const errorText = document.getElementById('error-text');
 const loginForm = document.getElementById('login-form');
 let captchaToken = '';
 window.onCaptchaSuccess = function(token){ captchaToken = token; };
+const CAPTCHA_MISSING_MSG = 'Veuillez compléter le captcha';
 function validateEmail(email) {
   const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return re.test(String(email).toLowerCase());
@@ -73,7 +74,7 @@ loginForm.addEventListener('submit', async function(e) {
     return;
   }
   if (!captchaToken) {
-    showError("Veuillez compléter le captcha");
+    showError(CAPTCHA_MISSING_MSG);
     return;
   }
   loginButton.disabled = true;

--- a/frontend/ressources/JS/signup.js
+++ b/frontend/ressources/JS/signup.js
@@ -33,6 +33,7 @@ const signupForm = document.getElementById('signup-form');
 const successState = document.getElementById('success-state');
 let captchaToken = '';
 window.onCaptchaSuccess = function(token){ captchaToken = token; };
+const CAPTCHA_MISSING_MSG = 'Veuillez compléter le captcha';
 function validateEmail(email) {
   const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return re.test(String(email).toLowerCase());
@@ -115,7 +116,7 @@ signupForm.addEventListener('submit', async function(e) {
     return;
   }
   if (!captchaToken) {
-    showError("Veuillez compléter le captcha");
+    showError(CAPTCHA_MISSING_MSG);
     return;
   }
   signupButton.disabled = true;


### PR DESCRIPTION
## Summary
- improve sign-in and sign-up JS to reuse a captcha missing constant
- return clearer error from API when captcha token isn't provided

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68447b041adc8320b6c06f8001c2fae9