### PR TITLE
Implement Go cleanup worker

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -34,7 +34,7 @@ API **ultra‑rapide** en **Go** 🐹 pour gérer tes **utilisateurs**, tes **o
 * Stats utilisateur intégrées (posts, likes, favoris…) 📊
 * Système de reports & modération 🕵️
 * Service **systemd** prêt à l'emploi 🚀
-* Script **`worker.py`** : purge auto des comptes non vérifiés 🧹
+* Worker interne en Go : purge auto des comptes non vérifiés 🧹
 
 ---
 
@@ -48,7 +48,7 @@ API **ultra‑rapide** en **Go** 🐹 pour gérer tes **utilisateurs**, tes **o
 │   ├── tools/        # my_tools.go
 │   └── user/         # avatar.go, me.go, profile.go, verify_email.go
 ├── utils/            # check.go (middlewares & helpers)
-├── worker.py         # purge comptes non vérifiés
+├── worker/           # cleanup worker intégré
 ├── start.sh          # démarrage dev "go run main.go"
 ├── main.go           # point d'entrée
 └── README.md         # ce fichier
@@ -180,6 +180,10 @@ cp config.sample.json config.json && nano config.json
         "port": 465,
         "username": "support@tool-center.fr",
         "password": "***"
+    },
+    "cleanup": {
+        "check_interval": 600,
+        "grace_period": 10
     }
 }
 ```
@@ -238,7 +242,7 @@ curl -H "Authorization: Bearer <token>" https://api.tool-center.fr/api/user/me |
 
 ## 🧹 Worker de nettoyage <a name="worker-de-nettoyage"></a>
 
-`worker.py` tourne chaque nuit (via cron ou `systemd.timer`) et **supprime** les comptes **non vérifiés** après X jours, ainsi que toutes les données liées (tokens, tools, comments…).
+Le worker Go embarqué tourne en continu et **supprime** les comptes **non vérifiés** après la période configurée. Il traite aussi la file d'attente d'emails.
 
 ---
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -44,6 +44,10 @@ type Config struct {
 		SignInSecret string `json:"signin_secret"`
 		SignUpSecret string `json:"signup_secret"`
 	} `json:"turnstile"`
+	Cleanup struct {
+		CheckInterval int `json:"check_interval"`
+		GracePeriod   int `json:"grace_period"`
+	} `json:"cleanup"`
 }
 
 func Load(path string) error {

--- a/api/example config.json
+++ b/api/example config.json
@@ -31,5 +31,9 @@
   "turnstile": {
     "signin_secret": "YOUR_SIGNIN_SECRET_KEY",
     "signup_secret": "YOUR_SIGNUP_SECRET_KEY"
+  },
+  "cleanup": {
+    "check_interval": 600,
+    "grace_period": 10
   }
 }

--- a/api/main.go
+++ b/api/main.go
@@ -10,6 +10,7 @@ import (
 	"toolcenter/scripts/tools"
 	"toolcenter/scripts/user"
 	"toolcenter/utils"
+	"toolcenter/worker"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/gin-gonic/gin"
@@ -138,6 +139,7 @@ func main() {
 
 	setupLogger()
 	go watchConfig(cfgPath)
+	go worker.Start()
 
 	cfg := config.Get()
 	if cfg.GinMode != "" {

--- a/api/worker/cleanup.go
+++ b/api/worker/cleanup.go
@@ -1,0 +1,93 @@
+package worker
+
+import (
+	"log"
+	"time"
+
+	"toolcenter/config"
+
+	_ "github.com/go-sql-driver/mysql"
+	"gopkg.in/gomail.v2"
+)
+
+// Start launches a periodic cleanup worker based on configuration values.
+func Start() {
+	cfg := config.Get()
+	if cfg.Cleanup.CheckInterval == 0 {
+		cfg.Cleanup.CheckInterval = 600
+	}
+	ticker := time.NewTicker(time.Duration(cfg.Cleanup.CheckInterval) * time.Second)
+	go func() {
+		for {
+			run()
+			<-ticker.C
+		}
+	}()
+}
+
+func run() {
+	cfg := config.Get()
+	db, err := config.OpenDB()
+	if err != nil {
+		log.Println("cleanup: open db:", err)
+		return
+	}
+	defer db.Close()
+
+	grace := cfg.Cleanup.GracePeriod
+	if grace == 0 {
+		grace = 10
+	}
+
+	rows, err := db.Query(`SELECT user_id,email FROM users WHERE email_verified_at IS NULL AND created_at < NOW() - INTERVAL ? MINUTE`, grace)
+	if err != nil {
+		log.Println("cleanup: select users:", err)
+		return
+	}
+	for rows.Next() {
+		var id, email string
+		if err := rows.Scan(&id, &email); err != nil {
+			log.Println("cleanup: scan user:", err)
+			continue
+		}
+		sendEmail(email, "Compte supprimé", "Votre compte a été supprimé faute de vérification.")
+		if _, err := db.Exec("DELETE FROM users WHERE user_id=?", id); err != nil {
+			log.Println("cleanup: delete user:", err)
+		}
+	}
+	rows.Close()
+
+	rows2, err := db.Query("SELECT queue_id,to_email,subject,body FROM email_queue")
+	if err != nil {
+		log.Println("cleanup: select queue:", err)
+		return
+	}
+	for rows2.Next() {
+		var qid int
+		var to, sub, body string
+		if err := rows2.Scan(&qid, &to, &sub, &body); err != nil {
+			log.Println("cleanup: scan queue:", err)
+			continue
+		}
+		sendEmail(to, sub, body)
+		if _, err := db.Exec("DELETE FROM email_queue WHERE queue_id=?", qid); err != nil {
+			log.Println("cleanup: delete queue:", err)
+		}
+	}
+	rows2.Close()
+}
+
+func sendEmail(to, subject, body string) {
+	cfg := config.Get()
+	msg := gomail.NewMessage()
+	msg.SetHeader("From", cfg.Email.From)
+	msg.SetHeader("To", to)
+	msg.SetHeader("Subject", subject)
+	msg.SetBody("text/plain", body)
+
+	d := gomail.NewDialer(cfg.Email.Host, cfg.Email.Port, cfg.Email.Username, cfg.Email.Password)
+	d.SSL = true
+	if err := d.DialAndSend(msg); err != nil {
+		log.Printf("cleanup: send email to %s failed: %v", to, err)
+	}
+}


### PR DESCRIPTION
## Summary
- extend config with `cleanup` section
- provide default cleanup values in the example config
- implement asynchronous cleanup worker in Go
- launch the worker in `main.go`
- document the cleanup worker and new config options

## Testing
- `go vet ./...` *(fails: forbidden downloading toolchain)*
- `go build ./...` *(fails: forbidden downloading toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6844b23778288320a8f8f3ba5dd1becf