### PR TITLE
Add admin routes with role checks

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"toolcenter/config"
+	"toolcenter/scripts/admin"
 	"toolcenter/scripts/auth"
 	"toolcenter/scripts/tools"
 	"toolcenter/scripts/user"
@@ -124,6 +125,14 @@ func setupRoutes(r *gin.Engine) {
 	toolsGroup.POST("/add", tools.SubmitToolHandler)
 	toolsGroup.GET("/me", tools.MyToolsHandler)
 	toolsGroup.DELETE("/delete/:id", tools.DeleteToolHandler)
+
+	adminGroup := api.Group("/admin")
+	adminGroup.Use(utils.RequireRole("Admin"))
+	adminGroup.GET("/users", admin.UserListHandler)
+	adminGroup.POST("/users/:id/ban", admin.BanUserHandler)
+
+	moderationGroup := api.Group("/moderation")
+	moderationGroup.Use(utils.RequireRole("Admin", "Moderator"))
 
 	utilsGroup := api.Group("/utils")
 	utilsGroup.POST("/privates_news", utils.PrivateNewsHandler)

--- a/api/scripts/admin/ban_user.go
+++ b/api/scripts/admin/ban_user.go
@@ -1,0 +1,46 @@
+package admin
+
+import (
+	"net/http"
+
+	"toolcenter/config"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type banRequest struct {
+	Reason string `json:"reason"`
+}
+
+func BanUserHandler(c *gin.Context) {
+	targetID := c.Param("id")
+	if targetID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
+		return
+	}
+
+	var req banRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.Reason == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "raison manquante"})
+		return
+	}
+
+	moderatorID, _ := c.Get("user_id")
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`UPDATE users SET account_status = 'Banned' WHERE user_id = ?`, targetID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	_, _ = db.Exec(`INSERT INTO moderation_actions (moderator_id, user_id, action_type, reason) VALUES (?, ?, 'Ban', ?)`, moderatorID, targetID, req.Reason)
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/api/scripts/admin/user_list.go
+++ b/api/scripts/admin/user_list.go
@@ -1,0 +1,64 @@
+package admin
+
+import (
+	"database/sql"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"toolcenter/config"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type UserInfo struct {
+	UserID   string    `json:"user_id"`
+	Username string    `json:"username"`
+	Email    string    `json:"email"`
+	Role     string    `json:"role"`
+	Status   string    `json:"status"`
+	Created  time.Time `json:"created_at"`
+}
+
+func UserListHandler(c *gin.Context) {
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	search := strings.TrimSpace(c.Query("search"))
+	page, _ := strconv.Atoi(c.Query("page"))
+	if page < 1 {
+		page = 1
+	}
+	limit := 50
+	offset := (page - 1) * limit
+
+	var rows *sql.Rows
+	if search != "" {
+		rows, err = db.Query(`SELECT user_id, username, email, role, account_status, created_at FROM users WHERE username LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?`, "%"+search+"%", limit, offset)
+	} else {
+		rows, err = db.Query(`SELECT user_id, username, email, role, account_status, created_at FROM users ORDER BY created_at DESC LIMIT ? OFFSET ?`, limit, offset)
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer rows.Close()
+
+	users := make([]UserInfo, 0)
+	for rows.Next() {
+		var u UserInfo
+		if err := rows.Scan(&u.UserID, &u.Username, &u.Email, &u.Role, &u.Status, &u.Created); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+			return
+		}
+		users = append(users, u)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "users": users})
+}

--- a/api/scripts/auth/login.go
+++ b/api/scripts/auth/login.go
@@ -92,7 +92,7 @@ func LoginHandler(c *gin.Context) {
 	c.Request.Body = http.NoBody
 	c.Set("user_id_override", uid)
 
-	if _, _, _, err = utils.Check(c, utils.CheckOpts{
+	if _, _, _, _, err = utils.Check(c, utils.CheckOpts{
 		RequireToken:     false,
 		RequireVerified:  true,
 		RequireNotBanned: true,

--- a/api/scripts/tools/delete_tool.go
+++ b/api/scripts/tools/delete_tool.go
@@ -14,7 +14,7 @@ import (
 )
 
 func DeleteToolHandler(c *gin.Context) {
-	uid, _, _, err := utils.Check(c, utils.CheckOpts{
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{
 		RequireToken:     true,
 		RequireVerified:  true,
 		RequireNotBanned: true,

--- a/api/scripts/tools/my_tools.go
+++ b/api/scripts/tools/my_tools.go
@@ -25,7 +25,7 @@ type Tool struct {
 }
 
 func MyToolsHandler(c *gin.Context) {
-	uid, _, _, err := utils.Check(c, utils.CheckOpts{
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{
 		RequireToken:     true,
 		RequireVerified:  true,
 		RequireNotBanned: true,

--- a/api/scripts/tools/submit_tool.go
+++ b/api/scripts/tools/submit_tool.go
@@ -31,7 +31,7 @@ func rnd() string {
 }
 
 func SubmitToolHandler(c *gin.Context) {
-	uid, _, _, err := utils.Check(c, utils.CheckOpts{
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{
 		RequireToken:     true,
 		RequireVerified:  true,
 		RequireNotBanned: true,

--- a/api/scripts/user/avatar.go
+++ b/api/scripts/user/avatar.go
@@ -19,7 +19,7 @@ import (
 )
 
 func UploadAvatar(c *gin.Context) {
-	uid, _, _, err := utils.Check(c, utils.CheckOpts{
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{
 		RequireToken:     true,
 		RequireVerified:  true,
 		RequireNotBanned: true,

--- a/api/scripts/user/delete_account.go
+++ b/api/scripts/user/delete_account.go
@@ -16,7 +16,7 @@ type deleteAccountRequest struct {
 }
 
 func DeleteAccountHandler(c *gin.Context) {
-	uid, _, _, err := utils.Check(c, utils.CheckOpts{
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{
 		RequireToken:     true,
 		RequireVerified:  true,
 		RequireNotBanned: true,

--- a/api/scripts/user/me.go
+++ b/api/scripts/user/me.go
@@ -26,7 +26,7 @@ func nTime(nt sql.NullTime) *time.Time {
 }
 
 func MeHandler(c *gin.Context) {
-	uid, _, _, err := utils.Check(c, utils.CheckOpts{
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{
 		RequireToken:     true,
 		RequireVerified:  true,
 		RequireNotBanned: true,

--- a/api/utils/roles.go
+++ b/api/utils/roles.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RequireRole(roles ...string) gin.HandlerFunc {
+	roleSet := make(map[string]struct{}, len(roles))
+	for _, r := range roles {
+		roleSet[r] = struct{}{}
+	}
+	return func(c *gin.Context) {
+		uid, _, userRole, _, err := Check(c, CheckOpts{
+			RequireToken:     true,
+			RequireVerified:  true,
+			RequireNotBanned: true,
+		})
+		if err != nil {
+			code := http.StatusInternalServerError
+			switch err {
+			case ErrMissingToken, ErrInvalidToken, ErrExpiredToken:
+				code = http.StatusUnauthorized
+			case ErrEmailNotVerified, ErrAccountBanned:
+				code = http.StatusForbidden
+			}
+			c.JSON(code, gin.H{"success": false, "message": err.Error()})
+			c.Abort()
+			return
+		}
+		if _, ok := roleSet[userRole]; !ok {
+			c.JSON(http.StatusForbidden, gin.H{"success": false, "message": "access denied"})
+			c.Abort()
+			return
+		}
+		c.Set("user_id", uid)
+		c.Set("role", userRole)
+		c.Next()
+	}
+}

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1199,8 +1199,9 @@
   <div class="toast-container" id="toast-container">
   </div>
 
+  <script src="panel-config.js"></script>
   <script>
-    let BASE_API_URL = '';
+    const BASE_API_URL = PANEL_CONFIG.ADMIN_BASE;
     let currentUserId = null;
     let currentPage = 1;
     let currentUserRole = null;
@@ -1270,20 +1271,6 @@
       });
     }
 
-    async function getBaseApiUrl() {
-      try {
-        const response = await fetch('/ressources/utils/api');
-        if (!response.ok) {
-          throw new Error('Failed to fetch API URL');
-        }
-        const textResponse = await response.text();
-        return textResponse.trim() || 'https://api.tool-center.fr/v1';
-        } catch (error) {
-        console.error('Error fetching API URL:', error);
-        showToast('error', 'Erreur de connexion à l\'API');
-        return 'https://api.tool-center.fr/v1';
-      }
-    }
 
     async function checkAdminPermissions() {
       try {
@@ -1882,12 +1869,6 @@
     }
 
     async function initAdminPanel() {
-      BASE_API_URL = await getBaseApiUrl();
-      if (!BASE_API_URL) {
-        showToast('error', 'Impossible de se connecter à l\'API');
-        return;
-      }
-      
       const isAdmin = await checkAdminPermissions();
       if (!isAdmin) {
         preloader.style.display = 'none';

--- a/frontend/admin2.html
+++ b/frontend/admin2.html
@@ -1038,6 +1038,7 @@
     <!-- Toasts will be added here dynamically -->
   </div>
 
+  <script src="panel-config.js"></script>
   <script>
     // Preloader
     window.addEventListener('load', function() {
@@ -1060,7 +1061,7 @@
     }
 
     // API functions
-    const API_BASE_URL = '/api/admin';
+    const API_BASE_URL = PANEL_CONFIG.ADMIN_BASE;
 
     async function fetchUsers(search = '', page = 1) {
       try {
@@ -1176,6 +1177,31 @@
         console.error('Error banning user:', error);
         return null;
       }
+    }
+
+    async function fetchStats() {
+      try {
+        const token = localStorage.getItem('token');
+        const res = await fetch(`${API_BASE_URL}/stats`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (!res.ok) {
+          throw new Error(`Erreur HTTP: ${res.status}`);
+        }
+        return await res.json();
+      } catch (err) {
+        console.error('Error fetching stats:', err);
+        return null;
+      }
+    }
+
+    async function loadStats() {
+      const stats = await fetchStats();
+      if (!stats) return;
+      document.getElementById('total-users').textContent = stats.total_users;
+      document.getElementById('new-users').textContent = stats.new_users;
+      document.getElementById('banned-users').textContent = stats.banned_users;
+      document.getElementById('moderators-count').textContent = stats.moderators;
     }
 
     // UI functions
@@ -1466,132 +1492,11 @@
       setupTabs();
       setupSearch();
       setupPagination();
-      
+
+      loadStats();
       loadUsers();
       loadSystemLogs();
-      
-      // Simulate stats loading
-      setTimeout(() => {
-        document.getElementById('total-users').textContent = '1,452';
-        document.getElementById('new-users').textContent = '124';
-        document.getElementById('banned-users').textContent = '23';
-        document.getElementById('moderators-count').textContent = '15';
-      }, 1000);
     });
-
-    // Simulate API data
-    window.mockUsers = [
-      {
-        _id: '1',
-        username: 'jdupont',
-        fullName: 'Jean Dupont',
-        email: 'jean.dupont@example.com',
-        avatar: '/assets/account.png',
-        createdAt: '2023-05-12T10:00:00Z',
-        status: 'active',
-        role: 'user'
-      },
-      {
-        _id: '2',
-        username: 'mleclerc',
-        fullName: 'Marie Leclerc',
-        email: 'marie.leclerc@example.com',
-        avatar: '/assets/account.png',
-        createdAt: '2023-06-15T14:30:00Z',
-        status: 'active',
-        role: 'moderator'
-      },
-      {
-        _id: '3',
-        username: 'pdurand',
-        fullName: 'Pierre Durand',
-        email: 'pierre.durand@example.com',
-        avatar: '/assets/account.png',
-        createdAt: '2023-07-20T09:15:00Z',
-        status: 'banned',
-        role: 'user',
-        banReason: 'Spam'
-      },
-      {
-        _id: '4',
-        username: 'lmoreau',
-        fullName: 'Lucie Moreau',
-        email: 'lucie.moreau@example.com',
-        avatar: '/assets/account.png',
-        createdAt: '2023-08-05T16:45:00Z',
-        status: 'active',
-        role: 'user'
-      },
-      {
-        _id: '5',
-        username: 'admin',
-        fullName: 'Admin ToolCenter',
-        email: 'admin@tool-center.fr',
-        avatar: '/assets/account.png',
-        createdAt: '2023-01-10T08:00:00Z',
-        status: 'active',
-        role: 'admin'
-      }
-    ];
-
-    window.mockLogs = [
-      {
-        _id: '1',
-        timestamp: '2023-11-15T09:30:00Z',
-        user: {
-          _id: '1',
-          username: 'jdupont',
-          avatar: '/assets/account.png'
-        },
-        action: 'Connexion',
-        details: 'Connexion réussie',
-        ipAddress: '192.168.1.1'
-      },
-      {
-        _id: '2',
-        timestamp: '2023-11-15T10:15:00Z',
-        user: {
-          _id: '5',
-          username: 'admin',
-          avatar: '/assets/account.png'
-        },
-        action: 'Modification utilisateur',
-        details: 'A modifié les permissions de l\'utilisateur mleclerc',
-        ipAddress: '192.168.1.100'
-      },
-      {
-        _id: '3',
-        timestamp: '2023-11-15T11:20:00Z',
-        user: null,
-        action: 'Maintenance',
-        details: 'Sauvegarde automatique de la base de données',
-        ipAddress: null
-      },
-      {
-        _id: '4',
-        timestamp: '2023-11-15T12:45:00Z',
-        user: {
-          _id: '3',
-          username: 'pdurand',
-          avatar: '/assets/account.png'
-        },
-        action: 'Ban',
-        details: 'A été banni pour spam',
-        ipAddress: '192.168.1.50'
-      },
-      {
-        _id: '5',
-        timestamp: '2023-11-15T14:00:00Z',
-        user: {
-          _id: '2',
-          username: 'mleclerc',
-          avatar: '/assets/account.png'
-        },
-        action: 'Modération',
-        details: 'A supprimé un commentaire inapproprié',
-        ipAddress: '192.168.1.75'
-      }
-    ];
   </script>
 </body>
 </html>

--- a/frontend/panel-config.js
+++ b/frontend/panel-config.js
@@ -1,0 +1,16 @@
+const PANEL_CONFIG = {
+  API_BASE: '/api/v1',
+  ADMIN_BASE: '/api/v1/admin',
+  MODERATION_BASE: '/api/v1/moderation',
+  COLORS: {
+    primary: '#6366f1',
+    success: '#10b981',
+    error: '#ef4444',
+    warning: '#f59e0b',
+    info: '#3b82f6'
+  }
+};
+
+for (const [name, value] of Object.entries(PANEL_CONFIG.COLORS)) {
+  document.documentElement.style.setProperty(`--${name}-color`, value);
+}


### PR DESCRIPTION
## Summary
- extend `Check` to return user role
- add middleware `RequireRole`
- implement admin handlers and groups
- add panel configuration script for frontend
- update admin panels to use config and real API calls

## Testing
- `go vet ./...` *(fails: Forbidden toolchain download)*

------
https://chatgpt.com/codex/tasks/task_e_6844c32e08ec8320b9c24f9639069880