### PR TITLE
Add admin stats and logs endpoints

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -129,7 +129,10 @@ func setupRoutes(r *gin.Engine) {
 	adminGroup := api.Group("/admin")
 	adminGroup.Use(utils.RequireRole("Admin"))
 	adminGroup.GET("/users", admin.UserListHandler)
+	adminGroup.GET("/users/:id", admin.UserDetailsHandler)
 	adminGroup.POST("/users/:id/ban", admin.BanUserHandler)
+	adminGroup.GET("/logs", admin.LogsHandler)
+	adminGroup.GET("/stats", admin.StatsHandler)
 
 	moderationGroup := api.Group("/moderation")
 	moderationGroup.Use(utils.RequireRole("Admin", "Moderator"))

--- a/api/scripts/admin/logs.go
+++ b/api/scripts/admin/logs.go
@@ -1,0 +1,71 @@
+package admin
+
+import (
+	"database/sql"
+	"net/http"
+	"strconv"
+	"time"
+
+	"toolcenter/config"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func LogsHandler(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	if page < 1 {
+		page = 1
+	}
+	limit := 50
+	offset := (page - 1) * limit
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`
+        SELECT al.created_at, al.event_type, al.target_resource, al.payload,
+               al.actor_user_id, u.username, u.avatar_url
+        FROM audit_logs al
+        LEFT JOIN users u ON u.user_id = al.actor_user_id
+        ORDER BY al.created_at DESC
+        LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer rows.Close()
+
+	logs := make([]gin.H, 0)
+	for rows.Next() {
+		var ts time.Time
+		var eventType, targetRes string
+		var payload sql.NullString
+		var actorID, username, avatar sql.NullString
+		if err := rows.Scan(&ts, &eventType, &targetRes, &payload, &actorID, &username, &avatar); err != nil {
+			continue
+		}
+		entry := gin.H{
+			"timestamp": ts,
+			"action":    eventType,
+			"details":   targetRes,
+		}
+		if payload.Valid && payload.String != "" {
+			entry["details"] = payload.String
+		}
+		if actorID.Valid {
+			user := gin.H{"user_id": actorID.String, "username": username.String}
+			if avatar.Valid {
+				user["avatar"] = avatar.String
+			}
+			entry["user"] = user
+		}
+		logs = append(logs, entry)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "logs": logs})
+}

--- a/api/scripts/admin/stats.go
+++ b/api/scripts/admin/stats.go
@@ -1,0 +1,59 @@
+package admin
+
+import (
+	"net/http"
+	"time"
+
+	"toolcenter/config"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func percentChange(curr, prev int) int {
+	if prev == 0 {
+		if curr == 0 {
+			return 0
+		}
+		return 100
+	}
+	return int(float64(curr-prev) / float64(prev) * 100)
+}
+
+func StatsHandler(c *gin.Context) {
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	var total, moderators, banned int
+	_ = db.QueryRow("SELECT COUNT(*) FROM users").Scan(&total)
+	_ = db.QueryRow("SELECT COUNT(*) FROM users WHERE role = 'Moderator'").Scan(&moderators)
+	_ = db.QueryRow("SELECT COUNT(*) FROM users WHERE account_status = 'Banned'").Scan(&banned)
+
+	var monthUsers, prevMonthUsers int
+	_ = db.QueryRow("SELECT COUNT(*) FROM users WHERE created_at >= DATE_FORMAT(NOW(), '%Y-%m-01')").Scan(&monthUsers)
+	_ = db.QueryRow("SELECT COUNT(*) FROM users WHERE created_at >= DATE_SUB(DATE_FORMAT(NOW(), '%Y-%m-01'), INTERVAL 1 MONTH) AND created_at < DATE_FORMAT(NOW(), '%Y-%m-01')").Scan(&prevMonthUsers)
+
+	var newUsers, prevNewUsers int
+	_ = db.QueryRow("SELECT COUNT(*) FROM users WHERE created_at >= NOW() - INTERVAL 7 DAY").Scan(&newUsers)
+	_ = db.QueryRow("SELECT COUNT(*) FROM users WHERE created_at >= NOW() - INTERVAL 14 DAY AND created_at < NOW() - INTERVAL 7 DAY").Scan(&prevNewUsers)
+
+	var bannedMonth, bannedPrevMonth int
+	_ = db.QueryRow("SELECT COUNT(*) FROM users WHERE account_status = 'Banned' AND created_at >= DATE_FORMAT(NOW(), '%Y-%m-01')").Scan(&bannedMonth)
+	_ = db.QueryRow("SELECT COUNT(*) FROM users WHERE account_status = 'Banned' AND created_at >= DATE_SUB(DATE_FORMAT(NOW(), '%Y-%m-01'), INTERVAL 1 MONTH) AND created_at < DATE_FORMAT(NOW(), '%Y-%m-01')").Scan(&bannedPrevMonth)
+
+	c.JSON(http.StatusOK, gin.H{
+		"success":           true,
+		"totalUsers":        total,
+		"userGrowth":        percentChange(monthUsers, prevMonthUsers),
+		"newUsers":          newUsers,
+		"newUsersGrowth":    percentChange(newUsers, prevNewUsers),
+		"bannedUsers":       banned,
+		"bannedUsersChange": percentChange(bannedMonth, bannedPrevMonth),
+		"moderators":        moderators,
+		"timestamp":         time.Now(),
+	})
+}

--- a/api/scripts/admin/user_details.go
+++ b/api/scripts/admin/user_details.go
@@ -1,0 +1,67 @@
+package admin
+
+import (
+	"database/sql"
+	"net/http"
+
+	"toolcenter/config"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func UserDetailsHandler(c *gin.Context) {
+	uid := c.Param("id")
+	if uid == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
+		return
+	}
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	var (
+		username, email, role, status string
+		avatar, bio                   sql.NullString
+		created                       sql.NullTime
+	)
+
+	err = db.QueryRow(`SELECT username,email,role,account_status,avatar_url,bio,created_at FROM users WHERE user_id = ?`, uid).
+		Scan(&username, &email, &role, &status, &avatar, &bio, &created)
+	if err == sql.ErrNoRows {
+		c.JSON(http.StatusNotFound, gin.H{"success": false, "message": "not found"})
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	var toolsCount int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM tools WHERE user_id = ?`, uid).Scan(&toolsCount)
+
+	user := gin.H{
+		"user_id":      uid,
+		"username":     username,
+		"email":        email,
+		"role":         role,
+		"status":       status,
+		"toolsCount":   toolsCount,
+		"reportsCount": 0,
+	}
+	if avatar.Valid {
+		user["avatar"] = avatar.String
+	}
+	if bio.Valid {
+		user["bio"] = bio.String
+	}
+	if created.Valid {
+		user["createdAt"] = created.Time
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "user": user})
+}


### PR DESCRIPTION
## Summary
- implement admin stats, logs and user details handlers
- expose the new routes in `main.go`

## Testing
- `go build ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_6845832607b0832086720fb658cbb079