### PR TITLE
Fix skeleton loops on admin panel

### DIFF
--- a/api/CONFIG DB ACTUELLE V6.sql
+++ b/api/CONFIG DB ACTUELLE V6.sql
@@ -239,6 +239,19 @@ CREATE TABLE audit_logs (
   FOREIGN KEY (target_user_id) REFERENCES users (user_id) ON DELETE SET NULL
 ) ENGINE = InnoDB ROW_FORMAT = COMPRESSED;
 
+CREATE TABLE activity_logs (
+  log_id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  user_id CHAR(36),
+  ip_address VARCHAR(45),
+  user_agent VARCHAR(255),
+  action VARCHAR(50),
+  success BOOLEAN,
+  message TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_activity_user (user_id, created_at),
+  FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE SET NULL
+) ENGINE = InnoDB ROW_FORMAT = COMPRESSED;
+
 -- ========= STATS & SOCIAL =========
 CREATE TABLE user_stats (
   stat_id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,

--- a/api/scripts/admin/ban_user.go
+++ b/api/scripts/admin/ban_user.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"toolcenter/config"
+	"toolcenter/utils"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/go-sql-driver/mysql"
@@ -16,12 +17,14 @@ type banRequest struct {
 func BanUserHandler(c *gin.Context) {
 	targetID := c.Param("id")
 	if targetID == "" {
+		utils.LogActivity(c, "", "ban_user", false, "id missing")
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
 		return
 	}
 
 	var req banRequest
 	if err := c.ShouldBindJSON(&req); err != nil || req.Reason == "" {
+		utils.LogActivity(c, "", "ban_user", false, "reason missing")
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "raison manquante"})
 		return
 	}
@@ -30,6 +33,7 @@ func BanUserHandler(c *gin.Context) {
 
 	db, err := config.OpenDB()
 	if err != nil {
+		utils.LogActivity(c, moderatorID.(string), "ban_user", false, "db open error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
@@ -37,10 +41,11 @@ func BanUserHandler(c *gin.Context) {
 
 	_, err = db.Exec(`UPDATE users SET account_status = 'Banned' WHERE user_id = ?`, targetID)
 	if err != nil {
+		utils.LogActivity(c, moderatorID.(string), "ban_user", false, "update error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
 	_, _ = db.Exec(`INSERT INTO moderation_actions (moderator_id, user_id, action_type, reason) VALUES (?, ?, 'Ban', ?)`, moderatorID, targetID, req.Reason)
-
+	utils.LogActivity(c, moderatorID.(string), "ban_user", true, "")
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/api/scripts/admin/unban_user.go
+++ b/api/scripts/admin/unban_user.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"toolcenter/config"
+	"toolcenter/utils"
 
 	"github.com/gin-gonic/gin"
 )
@@ -11,6 +12,7 @@ import (
 func UnbanUserHandler(c *gin.Context) {
 	uid := c.Param("id")
 	if uid == "" {
+		utils.LogActivity(c, "", "unban_user", false, "id manquant")
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
 		return
 	}
@@ -19,6 +21,7 @@ func UnbanUserHandler(c *gin.Context) {
 
 	db, err := config.OpenDB()
 	if err != nil {
+		utils.LogActivity(c, moderatorID.(string), "unban_user", false, "db open error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
@@ -26,10 +29,11 @@ func UnbanUserHandler(c *gin.Context) {
 
 	_, err = db.Exec(`UPDATE users SET account_status = 'Good' WHERE user_id = ?`, uid)
 	if err != nil {
+		utils.LogActivity(c, moderatorID.(string), "unban_user", false, "update error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
 	_, _ = db.Exec(`INSERT INTO moderation_actions (moderator_id, user_id, action_type) VALUES (?, ?, 'Unban')`, moderatorID, uid)
-
+	utils.LogActivity(c, moderatorID.(string), "unban_user", true, "")
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/api/scripts/admin/update_user.go
+++ b/api/scripts/admin/update_user.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"toolcenter/config"
+	"toolcenter/utils"
 
 	"github.com/gin-gonic/gin"
 )
@@ -19,18 +20,21 @@ type updateUserRequest struct {
 func UpdateUserHandler(c *gin.Context) {
 	uid := c.Param("id")
 	if uid == "" {
+		utils.LogActivity(c, "", "update_user", false, "id manquant")
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
 		return
 	}
 
 	var req updateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.LogActivity(c, "", "update_user", false, "invalid data")
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "données invalides"})
 		return
 	}
 
 	db, err := config.OpenDB()
 	if err != nil {
+		utils.LogActivity(c, "", "update_user", false, "db open error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
@@ -39,9 +43,10 @@ func UpdateUserHandler(c *gin.Context) {
 	_, err = db.Exec(`UPDATE users SET username=?, email=?, role=?, account_status=?, bio=? WHERE user_id=?`,
 		req.Username, req.Email, req.Role, req.Status, req.Bio, uid)
 	if err != nil {
+		utils.LogActivity(c, "", "update_user", false, "update error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
-
+	utils.LogActivity(c, "", "update_user", true, "")
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/api/scripts/user/delete_account.go
+++ b/api/scripts/user/delete_account.go
@@ -29,18 +29,21 @@ func DeleteAccountHandler(c *gin.Context) {
 		case utils.ErrEmailNotVerified, utils.ErrAccountBanned:
 			code = http.StatusForbidden
 		}
+		utils.LogActivity(c, uid, "delete_account", false, err.Error())
 		c.JSON(code, gin.H{"success": false, "message": err.Error()})
 		return
 	}
 
 	var req deleteAccountRequest
 	if err := c.ShouldBindJSON(&req); err != nil || req.Password == "" {
+		utils.LogActivity(c, uid, "delete_account", false, "password missing")
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "Mot de passe requis"})
 		return
 	}
 
 	db, err := config.OpenDB()
 	if err != nil {
+		utils.LogActivity(c, uid, "delete_account", false, "db open error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
@@ -49,20 +52,23 @@ func DeleteAccountHandler(c *gin.Context) {
 	var hash string
 	err = db.QueryRow(`SELECT password_hash FROM users WHERE user_id = ?`, uid).Scan(&hash)
 	if err != nil {
+		utils.LogActivity(c, uid, "delete_account", false, "select error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
 
 	if bcrypt.CompareHashAndPassword([]byte(hash), []byte(req.Password)) != nil {
+		utils.LogActivity(c, uid, "delete_account", false, "wrong password")
 		c.JSON(http.StatusUnauthorized, gin.H{"success": false, "message": "Mot de passe incorrect"})
 		return
 	}
 
 	_, err = db.Exec(`DELETE FROM users WHERE user_id = ?`, uid)
 	if err != nil {
+		utils.LogActivity(c, uid, "delete_account", false, "delete error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
-
+	utils.LogActivity(c, uid, "delete_account", true, "")
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/api/utils/activity_log.go
+++ b/api/utils/activity_log.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"database/sql"
+
+	"toolcenter/config"
+
+	"github.com/gin-gonic/gin"
+)
+
+// LogActivity stores an action made by a user or guest in the database.
+// If userID is empty, the value is stored as NULL.
+func LogActivity(c *gin.Context, userID, action string, success bool, message string) {
+	db, err := config.OpenDB()
+	if err != nil {
+		return
+	}
+	defer db.Close()
+
+	ip := c.ClientIP()
+	ua := c.Request.UserAgent()
+
+	var uid interface{}
+	if userID == "" {
+		uid = sql.NullString{}
+	} else {
+		uid = userID
+	}
+
+	_, _ = db.Exec(`INSERT INTO activity_logs (user_id, ip_address, user_agent, action, success, message) VALUES (?, ?, ?, ?, ?, ?)`,
+		uid, ip, ua, action, success, message)
+}

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -1192,6 +1192,7 @@
   <script src="/ressources/utils/panel-config.js"></script>
   <script>
     const BASE_API_URL = PANEL_CONFIG.API_BASE;
+    const SECTION_IDS = { users: 'users-section', logs: 'logs-section' };
     let currentUserId = null;
     let currentPage = 1;
     let currentUserRole = null;
@@ -1889,28 +1890,46 @@
     }
 
     async function loadUsers(search = '') {
+      const existing = document.getElementById(SECTION_IDS.users);
+      if (existing) existing.remove();
+
+      const placeholder = renderUsersTable([]);
+      placeholder.id = SECTION_IDS.users;
+      adminContent.appendChild(placeholder);
+      showLoadingSkeleton('users');
+
       const { users } = await fetchUsers(search);
       const usersElement = renderUsersTable(users);
-      
+      usersElement.id = SECTION_IDS.users;
+
       if (!document.querySelector('.stats-cards')) {
         await loadStats();
       }
-      
-      adminContent.appendChild(usersElement);
+
+      placeholder.replaceWith(usersElement);
     }
 
-    async function loadSystemLogs() {
-      const { logs } = await fetchSystemLogs();
+    async function loadSystemLogs(page = 1) {
+      const existing = document.getElementById(SECTION_IDS.logs);
+      if (existing) existing.remove();
+
+      const placeholder = renderSystemLogs([]);
+      placeholder.id = SECTION_IDS.logs;
+      adminContent.appendChild(placeholder);
+      showLoadingSkeleton('logs');
+
+      const { logs } = await fetchSystemLogs(page);
       const logsElement = renderSystemLogs(logs);
-      
+      logsElement.id = SECTION_IDS.logs;
+
       if (!document.querySelector('.stats-cards')) {
         await loadStats();
       }
-      if (!document.querySelector('#users-table-body')) {
+      if (!document.getElementById(SECTION_IDS.users)) {
         await loadUsers();
       }
-      
-      adminContent.appendChild(logsElement);
+
+      placeholder.replaceWith(logsElement);
     }
 
     async function initAdminPanel() {
@@ -1939,7 +1958,7 @@
       
       document.getElementById('save-changes').addEventListener('click', async () => {
         if (!currentUserId) return;
-        
+
         const userData = {
           username: document.getElementById('username').value,
           email: document.getElementById('email').value,
@@ -1947,16 +1966,11 @@
           role: document.getElementById('user-role').value,
           status: document.getElementById('account-status').value
         };
-        
+
         const result = await updateUser(currentUserId, userData);
         if (result) {
           closeUserModal();
-          const usersTable = document.querySelector('#users-table-body');
-          if (usersTable) {
-            usersTable.innerHTML = '';
-            const { users } = await fetchUsers();
-            renderUsersTable(users);
-          }
+          await loadUsers();
         }
       });
       
@@ -1968,8 +1982,7 @@
             const result = await unbanUser(currentUserId);
             if (result) {
               closeUserModal();
-              const { users } = await fetchUsers();
-              renderUsersTable(users);
+              await loadUsers();
             }
           }
         } else {
@@ -1978,8 +1991,7 @@
             const result = await banUser(currentUserId, reason);
             if (result) {
               closeUserModal();
-              const { users } = await fetchUsers();
-              renderUsersTable(users);
+              await loadUsers();
             }
           }
         }


### PR DESCRIPTION
## Summary
- ensure admin sections are replaced when reloading
- reload user list after updates and bans
- define section IDs to allow easier configuration
- record activity logs for many API endpoints

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684752b96e7483208b52296d0806322c