### PR TITLE
Fix admin logs and add user activity display

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -133,6 +133,7 @@ func setupRoutes(r *gin.Engine) {
 	adminGroup.PUT("/users/:id", admin.UpdateUserHandler)
 	adminGroup.POST("/users/:id/ban", admin.BanUserHandler)
 	adminGroup.POST("/users/:id/unban", admin.UnbanUserHandler)
+	adminGroup.GET("/users/:id/activity", admin.UserActivityHandler)
 	adminGroup.GET("/logs", admin.LogsHandler)
 	adminGroup.GET("/stats", admin.StatsHandler)
 

--- a/api/scripts/admin/logs.go
+++ b/api/scripts/admin/logs.go
@@ -12,12 +12,14 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
+const logsPerPage = 50
+
 func LogsHandler(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	if page < 1 {
 		page = 1
 	}
-	limit := 50
+	limit := logsPerPage
 	offset := (page - 1) * limit
 
 	db, err := config.OpenDB()
@@ -28,10 +30,10 @@ func LogsHandler(c *gin.Context) {
 	defer db.Close()
 
 	rows, err := db.Query(`
-        SELECT al.created_at, al.event_type, al.target_resource, al.payload,
-               al.actor_user_id, u.username, u.avatar_url
-        FROM audit_logs al
-        LEFT JOIN users u ON u.user_id = al.actor_user_id
+        SELECT al.created_at, al.action, al.message, al.success, al.ip_address,
+               al.user_id, u.username, u.avatar_url
+        FROM activity_logs al
+        LEFT JOIN users u ON u.user_id = al.user_id
         ORDER BY al.created_at DESC
         LIMIT ? OFFSET ?`, limit, offset)
 	if err != nil {
@@ -43,22 +45,26 @@ func LogsHandler(c *gin.Context) {
 	logs := make([]gin.H, 0)
 	for rows.Next() {
 		var ts time.Time
-		var eventType, targetRes string
-		var payload sql.NullString
-		var actorID, username, avatar sql.NullString
-		if err := rows.Scan(&ts, &eventType, &targetRes, &payload, &actorID, &username, &avatar); err != nil {
+		var action, message string
+		var success bool
+		var ip sql.NullString
+		var userID, username, avatar sql.NullString
+		if err := rows.Scan(&ts, &action, &message, &success, &ip, &userID, &username, &avatar); err != nil {
 			continue
 		}
 		entry := gin.H{
 			"timestamp": ts,
-			"action":    eventType,
-			"details":   targetRes,
+			"action":    action,
+			"success":   success,
 		}
-		if payload.Valid && payload.String != "" {
-			entry["details"] = payload.String
+		if message != "" {
+			entry["details"] = message
 		}
-		if actorID.Valid {
-			user := gin.H{"user_id": actorID.String, "username": username.String}
+		if ip.Valid {
+			entry["ip"] = ip.String
+		}
+		if userID.Valid {
+			user := gin.H{"user_id": userID.String, "username": username.String}
 			if avatar.Valid {
 				user["avatar"] = avatar.String
 			}

--- a/api/scripts/admin/user_activity.go
+++ b/api/scripts/admin/user_activity.go
@@ -1,0 +1,76 @@
+package admin
+
+import (
+	"database/sql"
+	"net/http"
+	"strconv"
+	"time"
+
+	"toolcenter/config"
+
+	"github.com/gin-gonic/gin"
+)
+
+const userActivityPerPage = 20
+
+func UserActivityHandler(c *gin.Context) {
+	uid := c.Param("id")
+	if uid == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
+		return
+	}
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	if page < 1 {
+		page = 1
+	}
+	limit := userActivityPerPage
+	offset := (page - 1) * limit
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT log_id, created_at, action, success, message, ip_address
+        FROM activity_logs WHERE user_id = ?
+        ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+		uid, limit, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer rows.Close()
+
+	logs := make([]gin.H, 0)
+	for rows.Next() {
+		var (
+			id      int
+			ts      time.Time
+			action  string
+			success bool
+			msg     sql.NullString
+			ip      sql.NullString
+		)
+		if err := rows.Scan(&id, &ts, &action, &success, &msg, &ip); err != nil {
+			continue
+		}
+		entry := gin.H{
+			"id":        id,
+			"timestamp": ts,
+			"action":    action,
+			"success":   success,
+		}
+		if msg.Valid {
+			entry["message"] = msg.String
+		}
+		if ip.Valid {
+			entry["ip"] = ip.String
+		}
+		logs = append(logs, entry)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "logs": logs})
+}

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -373,6 +373,43 @@
       flex: 1;
     }
 
+    .activity-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .activity-item {
+      display: flex;
+      align-items: center;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border-color);
+      font-size: 14px;
+    }
+
+    .activity-item:last-child {
+      border-bottom: none;
+    }
+
+    .activity-date {
+      width: 130px;
+      color: #94a3b8;
+      font-size: 12px;
+    }
+
+    .activity-action {
+      flex: 1;
+      margin: 0 10px;
+    }
+
+    .activity-success {
+      color: var(--success-color);
+    }
+
+    .activity-fail {
+      color: var(--error-color);
+    }
+
     .admin-table-container {
       background: var(--card-bg);
       border-radius: 12px;
@@ -1345,6 +1382,23 @@
       }
     }
 
+    async function fetchUserActivity(userId) {
+      try {
+        const token = localStorage.getItem('token');
+        const response = await fetch(`${BASE_API_URL}/admin/users/${userId}/activity`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP error: ${response.status}`);
+        }
+        return await response.json();
+      } catch (error) {
+        showToast('error', `Erreur lors du chargement de l'activité: ${error.message}`);
+        console.error('Error fetching user activity:', error);
+        return { logs: [] };
+      }
+    }
+
     async function fetchSystemLogs(page = 1) {
       showLoadingSkeleton('logs');
       
@@ -1793,8 +1847,8 @@
             ` : 'Système'}
           </td>
           <td>${log.action}</td>
-          <td>${log.details}</td>
-          <td>${log.ipAddress || 'N/A'}</td>
+          <td>${log.details || ''}</td>
+          <td>${log.ip || 'N/A'}</td>
         `;
         tbody.appendChild(tr);
       });
@@ -1809,6 +1863,29 @@
         }, 500);
       });
       
+      return container;
+    }
+
+    function renderUserActivity(logs) {
+      const container = document.createElement('div');
+      if (!logs.length) {
+        container.innerHTML = '<p>Aucune activité récente.</p>';
+        return container;
+      }
+      const list = document.createElement('ul');
+      list.className = 'activity-list';
+      logs.forEach(log => {
+        const li = document.createElement('li');
+        li.className = 'activity-item';
+        li.innerHTML = `
+          <span class="activity-date">${new Date(log.timestamp).toLocaleString()}</span>
+          <span class="activity-action">${log.action}${log.message ? ' - ' + log.message : ''}</span>
+          <span class="${log.success ? 'activity-success' : 'activity-fail'}">
+            <i class="fas fa-${log.success ? 'check-circle' : 'times-circle'}"></i>
+          </span>`;
+        list.appendChild(li);
+      });
+      container.appendChild(list);
       return container;
     }
 
@@ -1861,6 +1938,12 @@
       document.getElementById('bio').value = user.bio || '';
       document.getElementById('user-role').value = user.role || 'User';
       document.getElementById('account-status').value = user.status || 'Good';
+
+      const activityTab = document.getElementById('activity-tab');
+      activityTab.innerHTML = '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
+      const activityData = await fetchUserActivity(userId);
+      activityTab.innerHTML = '';
+      activityTab.appendChild(renderUserActivity(activityData.logs || []));
     }
 
     function closeUserModal() {


### PR DESCRIPTION
## Summary
- query the proper activity_logs table for admin logs
- implement user activity endpoint in the API
- expose new route in main
- display user activity in admin modal and add styles

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68486bd7c984832093b230370f8d27f9