### PR TITLE
Fix admin logs and add user activity display

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -133,6 +133,7 @@ func setupRoutes(r *gin.Engine) {
 	adminGroup.PUT("/users/:id", admin.UpdateUserHandler)
 	adminGroup.POST("/users/:id/ban", admin.BanUserHandler)
 	adminGroup.POST("/users/:id/unban", admin.UnbanUserHandler)
+	adminGroup.GET("/users/:id/activity", admin.UserActivityHandler)
 	adminGroup.GET("/logs", admin.LogsHandler)
 	adminGroup.GET("/stats", admin.StatsHandler)
 

--- a/api/scripts/admin/logs.go
+++ b/api/scripts/admin/logs.go
@@ -7,34 +7,41 @@ import (
 	"time"
 
 	"toolcenter/config"
+	"toolcenter/utils"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/go-sql-driver/mysql"
 )
+
+const logsPerPage = 50
 
 func LogsHandler(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	if page < 1 {
 		page = 1
 	}
-	limit := 50
+	limit := logsPerPage
 	offset := (page - 1) * limit
+
+	adminID, _ := c.Get("user_id")
 
 	db, err := config.OpenDB()
 	if err != nil {
+		utils.LogActivity(c, adminID.(string), "list_logs", false, "db open error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
 	defer db.Close()
 
 	rows, err := db.Query(`
-        SELECT al.created_at, al.event_type, al.target_resource, al.payload,
-               al.actor_user_id, u.username, u.avatar_url
-        FROM audit_logs al
-        LEFT JOIN users u ON u.user_id = al.actor_user_id
+        SELECT al.created_at, al.action, al.message, al.success, al.ip_address,
+               al.user_id, u.username, u.avatar_url
+        FROM activity_logs al
+        LEFT JOIN users u ON u.user_id = al.user_id
         ORDER BY al.created_at DESC
         LIMIT ? OFFSET ?`, limit, offset)
 	if err != nil {
+		utils.LogActivity(c, adminID.(string), "list_logs", false, "query error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
@@ -43,22 +50,26 @@ func LogsHandler(c *gin.Context) {
 	logs := make([]gin.H, 0)
 	for rows.Next() {
 		var ts time.Time
-		var eventType, targetRes string
-		var payload sql.NullString
-		var actorID, username, avatar sql.NullString
-		if err := rows.Scan(&ts, &eventType, &targetRes, &payload, &actorID, &username, &avatar); err != nil {
+		var action, message string
+		var success bool
+		var ip sql.NullString
+		var userID, username, avatar sql.NullString
+		if err := rows.Scan(&ts, &action, &message, &success, &ip, &userID, &username, &avatar); err != nil {
 			continue
 		}
 		entry := gin.H{
 			"timestamp": ts,
-			"action":    eventType,
-			"details":   targetRes,
+			"action":    action,
+			"success":   success,
 		}
-		if payload.Valid && payload.String != "" {
-			entry["details"] = payload.String
+		if message != "" {
+			entry["details"] = message
 		}
-		if actorID.Valid {
-			user := gin.H{"user_id": actorID.String, "username": username.String}
+		if ip.Valid {
+			entry["ip"] = ip.String
+		}
+		if userID.Valid {
+			user := gin.H{"user_id": userID.String, "username": username.String}
 			if avatar.Valid {
 				user["avatar"] = avatar.String
 			}
@@ -67,5 +78,6 @@ func LogsHandler(c *gin.Context) {
 		logs = append(logs, entry)
 	}
 
+	utils.LogActivity(c, adminID.(string), "list_logs", true, "")
 	c.JSON(http.StatusOK, gin.H{"success": true, "logs": logs})
 }

--- a/api/scripts/admin/stats.go
+++ b/api/scripts/admin/stats.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"toolcenter/config"
+	"toolcenter/utils"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/go-sql-driver/mysql"
@@ -21,8 +22,11 @@ func percentChange(curr, prev int) int {
 }
 
 func StatsHandler(c *gin.Context) {
+	adminID, _ := c.Get("user_id")
+
 	db, err := config.OpenDB()
 	if err != nil {
+		utils.LogActivity(c, adminID.(string), "view_stats", false, "db open error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
@@ -56,4 +60,5 @@ func StatsHandler(c *gin.Context) {
 		"moderators":        moderators,
 		"timestamp":         time.Now(),
 	})
+	utils.LogActivity(c, adminID.(string), "view_stats", true, "")
 }

--- a/api/scripts/admin/user_activity.go
+++ b/api/scripts/admin/user_activity.go
@@ -1,0 +1,82 @@
+package admin
+
+import (
+	"database/sql"
+	"net/http"
+	"strconv"
+	"time"
+
+	"toolcenter/config"
+	"toolcenter/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+const userActivityPerPage = 20
+
+func UserActivityHandler(c *gin.Context) {
+	uid := c.Param("id")
+	if uid == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
+		return
+	}
+
+	adminID, _ := c.Get("user_id")
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	if page < 1 {
+		page = 1
+	}
+	limit := userActivityPerPage
+	offset := (page - 1) * limit
+
+	db, err := config.OpenDB()
+	if err != nil {
+		utils.LogActivity(c, adminID.(string), "view_user_activity", false, "db open error")
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT log_id, created_at, action, success, message, ip_address
+        FROM activity_logs WHERE user_id = ?
+        ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+		uid, limit, offset)
+	if err != nil {
+		utils.LogActivity(c, adminID.(string), "view_user_activity", false, "query error")
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer rows.Close()
+
+	logs := make([]gin.H, 0)
+	for rows.Next() {
+		var (
+			id      int
+			ts      time.Time
+			action  string
+			success bool
+			msg     sql.NullString
+			ip      sql.NullString
+		)
+		if err := rows.Scan(&id, &ts, &action, &success, &msg, &ip); err != nil {
+			continue
+		}
+		entry := gin.H{
+			"id":        id,
+			"timestamp": ts,
+			"action":    action,
+			"success":   success,
+		}
+		if msg.Valid {
+			entry["message"] = msg.String
+		}
+		if ip.Valid {
+			entry["ip"] = ip.String
+		}
+		logs = append(logs, entry)
+	}
+
+	utils.LogActivity(c, adminID.(string), "view_user_activity", true, "")
+	c.JSON(http.StatusOK, gin.H{"success": true, "logs": logs})
+}

--- a/api/scripts/admin/user_details.go
+++ b/api/scripts/admin/user_details.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"toolcenter/config"
+	"toolcenter/utils"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/go-sql-driver/mysql"
@@ -17,8 +18,11 @@ func UserDetailsHandler(c *gin.Context) {
 		return
 	}
 
+	adminID, _ := c.Get("user_id")
+
 	db, err := config.OpenDB()
 	if err != nil {
+		utils.LogActivity(c, adminID.(string), "view_user_details", false, "db open error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
@@ -37,6 +41,7 @@ func UserDetailsHandler(c *gin.Context) {
 		return
 	}
 	if err != nil {
+		utils.LogActivity(c, adminID.(string), "view_user_details", false, "query error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
@@ -63,5 +68,6 @@ func UserDetailsHandler(c *gin.Context) {
 		user["createdAt"] = created.Time
 	}
 
+	utils.LogActivity(c, adminID.(string), "view_user_details", true, "")
 	c.JSON(http.StatusOK, gin.H{"success": true, "user": user})
 }

--- a/api/scripts/tools/my_tools.go
+++ b/api/scripts/tools/my_tools.go
@@ -32,12 +32,14 @@ func MyToolsHandler(c *gin.Context) {
 		UpdateLastLogin:  true,
 	})
 	if err != nil {
+		utils.LogActivity(c, uid, "my_tools", false, err.Error())
 		c.JSON(http.StatusUnauthorized, gin.H{"success": false, "message": err.Error()})
 		return
 	}
 
 	db, err := config.OpenDB()
 	if err != nil {
+		utils.LogActivity(c, uid, "my_tools", false, "db open error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "message": "Erreur DB."})
 		return
 	}
@@ -45,6 +47,7 @@ func MyToolsHandler(c *gin.Context) {
 
 	rows, err := db.Query(`SELECT tool_id, user_id, title, description, content_url, thumbnail_url, status, views, created_at, updated_at FROM tools WHERE user_id = ? ORDER BY created_at DESC`, uid)
 	if err != nil {
+		utils.LogActivity(c, uid, "my_tools", false, "query error")
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "message": "Erreur DB."})
 		return
 	}
@@ -54,11 +57,13 @@ func MyToolsHandler(c *gin.Context) {
 	for rows.Next() {
 		var t Tool
 		if err := rows.Scan(&t.ID, &t.UserID, &t.Title, &t.Description, &t.ContentURL, &t.ThumbnailURL, &t.Status, &t.Views, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			utils.LogActivity(c, uid, "my_tools", false, "scan error")
 			c.JSON(http.StatusInternalServerError, gin.H{"success": false, "message": "Erreur DB."})
 			return
 		}
 		tools = append(tools, t)
 	}
 
+	utils.LogActivity(c, uid, "my_tools", true, "")
 	c.JSON(http.StatusOK, gin.H{"success": true, "tools": tools})
 }

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -373,6 +373,43 @@
       flex: 1;
     }
 
+    .activity-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .activity-item {
+      display: flex;
+      align-items: center;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border-color);
+      font-size: 14px;
+    }
+
+    .activity-item:last-child {
+      border-bottom: none;
+    }
+
+    .activity-date {
+      width: 130px;
+      color: #94a3b8;
+      font-size: 12px;
+    }
+
+    .activity-action {
+      flex: 1;
+      margin: 0 10px;
+    }
+
+    .activity-success {
+      color: var(--success-color);
+    }
+
+    .activity-fail {
+      color: var(--error-color);
+    }
+
     .admin-table-container {
       background: var(--card-bg);
       border-radius: 12px;
@@ -1345,6 +1382,23 @@
       }
     }
 
+    async function fetchUserActivity(userId) {
+      try {
+        const token = localStorage.getItem('token');
+        const response = await fetch(`${BASE_API_URL}/admin/users/${userId}/activity`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP error: ${response.status}`);
+        }
+        return await response.json();
+      } catch (error) {
+        showToast('error', `Erreur lors du chargement de l'activité: ${error.message}`);
+        console.error('Error fetching user activity:', error);
+        return { logs: [] };
+      }
+    }
+
     async function fetchSystemLogs(page = 1) {
       showLoadingSkeleton('logs');
       
@@ -1793,8 +1847,8 @@
             ` : 'Système'}
           </td>
           <td>${log.action}</td>
-          <td>${log.details}</td>
-          <td>${log.ipAddress || 'N/A'}</td>
+          <td>${log.details || ''}</td>
+          <td>${log.ip || 'N/A'}</td>
         `;
         tbody.appendChild(tr);
       });
@@ -1809,6 +1863,29 @@
         }, 500);
       });
       
+      return container;
+    }
+
+    function renderUserActivity(logs) {
+      const container = document.createElement('div');
+      if (!logs.length) {
+        container.innerHTML = '<p>Aucune activité récente.</p>';
+        return container;
+      }
+      const list = document.createElement('ul');
+      list.className = 'activity-list';
+      logs.forEach(log => {
+        const li = document.createElement('li');
+        li.className = 'activity-item';
+        li.innerHTML = `
+          <span class="activity-date">${new Date(log.timestamp).toLocaleString()}</span>
+          <span class="activity-action">${log.action}${log.message ? ' - ' + log.message : ''}</span>
+          <span class="${log.success ? 'activity-success' : 'activity-fail'}">
+            <i class="fas fa-${log.success ? 'check-circle' : 'times-circle'}"></i>
+          </span>`;
+        list.appendChild(li);
+      });
+      container.appendChild(list);
       return container;
     }
 
@@ -1861,6 +1938,12 @@
       document.getElementById('bio').value = user.bio || '';
       document.getElementById('user-role').value = user.role || 'User';
       document.getElementById('account-status').value = user.status || 'Good';
+
+      const activityTab = document.getElementById('activity-tab');
+      activityTab.innerHTML = '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
+      const activityData = await fetchUserActivity(userId);
+      activityTab.innerHTML = '';
+      activityTab.appendChild(renderUserActivity(activityData.logs || []));
     }
 
     function closeUserModal() {


### PR DESCRIPTION
## Summary
- query the proper activity_logs table for admin logs
- implement user activity endpoint in the API
- expose new route in main
- display user activity in admin modal and add styles
- add missing activity logging across handlers

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68486bd7c984832093b230370f8d27f9