### PR TITLE
Add moderation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - 💬 **Liker, commenter et partager** ceux des autres
 - 👤 **Gérer ton compte** : avatar, paramètres, stats persos
 - 🛡️ Un **système de modération** ultra propre
+- ⚖️ **Sanctions contestables** via un panel dédié
 - 📜 **Logs complets** : utilisateurs, admins, actions
 - ⚡ Un **design responsive**, fluide et sans chichis
 

--- a/api/CONFIG DB ACTUELLE V6.sql
+++ b/api/CONFIG DB ACTUELLE V6.sql
@@ -295,3 +295,29 @@ CREATE TABLE email_queue (
   body     TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE = InnoDB;
+
+-- ========= SANCTIONS =========
+CREATE TABLE sanctions (
+  sanction_id CHAR(36) PRIMARY KEY,
+  user_id CHAR(36) NOT NULL,
+  moderator_id CHAR(36) NOT NULL,
+  type ENUM('Warn','Ban','Limit') NOT NULL,
+  reason TEXT,
+  not_contestable BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  expires_at DATETIME,
+  FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE,
+  FOREIGN KEY (moderator_id) REFERENCES users (user_id) ON DELETE SET NULL
+) ENGINE = InnoDB;
+
+CREATE TABLE sanction_appeals (
+  appeal_id CHAR(36) PRIMARY KEY,
+  sanction_id CHAR(36) NOT NULL,
+  user_id CHAR(36) NOT NULL,
+  message TEXT,
+  status ENUM('Pending','Approved','Rejected') DEFAULT 'Pending',
+  response TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (sanction_id) REFERENCES sanctions (sanction_id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
+) ENGINE = InnoDB;

--- a/api/main.go
+++ b/api/main.go
@@ -8,6 +8,7 @@ import (
 	"toolcenter/config"
 	"toolcenter/scripts/admin"
 	"toolcenter/scripts/auth"
+	"toolcenter/scripts/moderation"
 	"toolcenter/scripts/tools"
 	"toolcenter/scripts/user"
 	"toolcenter/utils"
@@ -127,6 +128,7 @@ func setupRoutes(r *gin.Engine) {
 	userGroup.POST("/update_username", user.UpdateUsernameHandler)
 	userGroup.POST("/update_email", user.UpdateEmailHandler)
 	userGroup.POST("/delete", user.DeleteAccountHandler)
+	userGroup.POST("/sanctions/:id/appeal", moderation.AppealSanctionHandler)
 
 	toolsGroup := api.Group("/tools")
 	toolsGroup.POST("/add", tools.SubmitToolHandler)
@@ -146,6 +148,9 @@ func setupRoutes(r *gin.Engine) {
 
 	moderationGroup := api.Group("/moderation")
 	moderationGroup.Use(utils.RequireRole("Admin", "Moderator"))
+	moderationGroup.POST("/sanctions/:id", moderation.CreateSanctionHandler)
+	moderationGroup.GET("/sanctions/:id", moderation.ListSanctionsHandler)
+	moderationGroup.GET("/appeals", moderation.ListAppealsHandler)
 
 	utilsGroup := api.Group("/utils")
 	utilsGroup.POST("/privates_news", utils.PrivateNewsHandler)

--- a/api/scripts/moderation/sanctions.go
+++ b/api/scripts/moderation/sanctions.go
@@ -1,0 +1,224 @@
+package moderation
+
+import (
+	"database/sql"
+	"net/http"
+	"time"
+
+	"toolcenter/config"
+	"toolcenter/utils"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
+)
+
+type SanctionRequest struct {
+	Type           string `json:"type"`
+	Reason         string `json:"reason"`
+	DurationHours  int    `json:"duration_hours"`
+	NotContestable bool   `json:"not_contestable"`
+}
+
+func CreateSanctionHandler(c *gin.Context) {
+	modID, _ := c.Get("user_id")
+	moderatorID, _ := modID.(string)
+
+	uid := c.Param("id")
+	if uid == "" {
+		utils.LogActivity(c, moderatorID, "create_sanction", false, "id manquant")
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
+		return
+	}
+
+	var req SanctionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.LogActivity(c, moderatorID, "create_sanction", false, "bad request")
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "requete invalide"})
+		return
+	}
+
+	db, err := config.OpenDB()
+	if err != nil {
+		utils.LogActivity(c, moderatorID, "create_sanction", false, "db open error")
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	uuidV7, _ := uuid.NewV7()
+	sanctionID := uuidV7.String()
+
+	var expires *time.Time
+	if req.DurationHours > 0 {
+		t := time.Now().Add(time.Duration(req.DurationHours) * time.Hour)
+		expires = &t
+	}
+
+	_, err = db.Exec(`INSERT INTO sanctions (sanction_id,user_id,moderator_id,type,reason,not_contestable,expires_at) VALUES (?,?,?,?,?,?,?)`,
+		sanctionID, uid, moderatorID, req.Type, req.Reason, req.NotContestable, expires)
+	if err != nil {
+		utils.LogActivity(c, moderatorID, "create_sanction", false, "insert error")
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	utils.LogActivity(c, moderatorID, "create_sanction", true, "")
+	c.JSON(http.StatusOK, gin.H{"success": true, "sanction_id": sanctionID})
+}
+
+func ListSanctionsHandler(c *gin.Context) {
+	modID, _ := c.Get("user_id")
+	moderatorID, _ := modID.(string)
+
+	uid := c.Param("id")
+	if uid == "" {
+		utils.LogActivity(c, moderatorID, "list_sanctions", false, "id manquant")
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
+		return
+	}
+
+	db, err := config.OpenDB()
+	if err != nil {
+		utils.LogActivity(c, moderatorID, "list_sanctions", false, "db open error")
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT sanction_id,type,reason,not_contestable,created_at,expires_at FROM sanctions WHERE user_id = ? ORDER BY created_at DESC`, uid)
+	if err != nil {
+		utils.LogActivity(c, moderatorID, "list_sanctions", false, "query error")
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer rows.Close()
+
+	sanctions := make([]gin.H, 0)
+	for rows.Next() {
+		var (
+			sid, typ, reason string
+			nc               bool
+			created, expires sql.NullTime
+		)
+		if err := rows.Scan(&sid, &typ, &reason, &nc, &created, &expires); err == nil {
+			s := gin.H{
+				"sanction_id":     sid,
+				"type":            typ,
+				"reason":          reason,
+				"not_contestable": nc,
+			}
+			if created.Valid {
+				s["created_at"] = created.Time
+			}
+			if expires.Valid {
+				s["expires_at"] = expires.Time
+			}
+			sanctions = append(sanctions, s)
+		}
+	}
+
+	utils.LogActivity(c, moderatorID, "list_sanctions", true, "")
+	c.JSON(http.StatusOK, gin.H{"success": true, "sanctions": sanctions})
+}
+
+func AppealSanctionHandler(c *gin.Context) {
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{RequireToken: true, RequireVerified: true, RequireNotBanned: true})
+	if err != nil {
+		code := http.StatusInternalServerError
+		switch err {
+		case utils.ErrMissingToken, utils.ErrInvalidToken, utils.ErrExpiredToken:
+			code = http.StatusUnauthorized
+		case utils.ErrEmailNotVerified, utils.ErrAccountBanned:
+			code = http.StatusForbidden
+		}
+		c.JSON(code, gin.H{"success": false, "message": err.Error()})
+		return
+	}
+
+	sanctionID := c.Param("id")
+	if sanctionID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "id manquant"})
+		return
+	}
+
+	var payload struct {
+		Message string `json:"message"`
+	}
+	if err := c.ShouldBindJSON(&payload); err != nil || payload.Message == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "requete invalide"})
+		return
+	}
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	var contestable bool
+	err = db.QueryRow(`SELECT not_contestable FROM sanctions WHERE sanction_id = ? AND user_id = ?`, sanctionID, uid).Scan(&contestable)
+	if err == sql.ErrNoRows {
+		c.JSON(http.StatusNotFound, gin.H{"success": false, "message": "sanction inconnue"})
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	if contestable {
+		uuidV7, _ := uuid.NewV7()
+		appealID := uuidV7.String()
+		_, err = db.Exec(`INSERT INTO sanction_appeals (appeal_id,sanction_id,user_id,message) VALUES (?,?,?,?)`, appealID, sanctionID, uid, payload.Message)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"success": true, "appeal_id": appealID})
+	} else {
+		c.JSON(http.StatusForbidden, gin.H{"success": false, "message": "cette sanction n'est pas contestable"})
+	}
+}
+
+func ListAppealsHandler(c *gin.Context) {
+	modID, _ := c.Get("user_id")
+	moderatorID, _ := modID.(string)
+
+	db, err := config.OpenDB()
+	if err != nil {
+		utils.LogActivity(c, moderatorID, "list_appeals", false, "db open error")
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT appeal_id,sanction_id,user_id,message,status,response,created_at FROM sanction_appeals ORDER BY created_at DESC`)
+	if err != nil {
+		utils.LogActivity(c, moderatorID, "list_appeals", false, "query error")
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer rows.Close()
+
+	appeals := make([]gin.H, 0)
+	for rows.Next() {
+		var id, sid, uid, message, status, response string
+		var created time.Time
+		if err := rows.Scan(&id, &sid, &uid, &message, &status, &response, &created); err == nil {
+			appeals = append(appeals, gin.H{
+				"appeal_id":   id,
+				"sanction_id": sid,
+				"user_id":     uid,
+				"message":     message,
+				"status":      status,
+				"response":    response,
+				"created_at":  created,
+			})
+		}
+	}
+
+	utils.LogActivity(c, moderatorID, "list_appeals", true, "")
+	c.JSON(http.StatusOK, gin.H{"success": true, "appeals": appeals})
+}

--- a/frontend/account/index.html
+++ b/frontend/account/index.html
@@ -1353,9 +1353,15 @@
                         </a>
                     </li>
                     <li>
-                        <a href="/account/profile">
-                            <img src="/assets/personnaliser.png" alt="Profil" class="sidebar-icon">
-                            Personnalisation
+                        <a href="/account/moderation">
+                            <img src="/assets/security-icon.png" alt="Modération" class="sidebar-icon">
+                            Modération / Sanctions
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/account/support">
+                            <img src="/assets/support.png" alt="Support" class="sidebar-icon">
+                            Support / Tickets
                         </a>
                     </li>
                     <li>
@@ -1402,7 +1408,6 @@
                 <div class="profile-card" style="padding:0;">
                     <div class="tabs-header">
                         <button class="tab-btn active" id="tabMainBtn">Infos principales</button>
-                        <button class="tab-btn" id="tabStatusBtn">Statut du compte</button>
                     </div>
                     <div class="tab-content active" id="tabMain">
                         <div class="profile-info" style="padding:30px;">
@@ -1430,27 +1435,6 @@
                                 <img src="/assets/show.png" alt="Afficher" class="email-toggle" id="toggleEmail">
                                 <img src="/assets/edit-icon.png" alt="Modifier" class="email-edit" id="editEmail">
                             </div>
-                        </div>
-                    </div>
-                    <div class="tab-content" id="tabStatus" style="padding:30px;">
-                        <h3 style="font-size:1.3rem;margin-bottom:18px;">Statut du compte</h3>
-                        <div id="status-bar-container">
-                            <div class="status-progress-bar" id="statusProgress">
-                                <div class="status-progress" id="statusProgressFill"></div>
-                            </div>
-                            <div class="status-labels">
-                                <span>Tout bon !</span>
-                                <span>Limité</span>
-                                <span>Très limité</span>
-                                <span>À risque</span>
-                                <span>Banni(e)</span>
-                            </div>
-                        </div>
-                        <div style="margin-top:20px;">
-                            <b>Votre statut :</b> <span id="accountStatusText" style="font-weight:bold;">Chargement...</span>
-                        </div>
-                        <div id="statusDescription" style="color:#aaa;margin-top:8px;font-size: 1rem;max-width: 600px;">
-                            Chargemment...
                         </div>
                     </div>
                 </div>
@@ -1687,7 +1671,6 @@
             document.querySelectorAll('.skeleton').forEach(el => {
                 el.classList.add('fade-out');
                 setTimeout(() => {
-                    setAccountStatus(userData.account_status);
                     el.classList.add('hidden');
                 }, 300);
             });
@@ -2011,21 +1994,10 @@
         // G0
         document.addEventListener('DOMContentLoaded', () => {
             const tabMainBtn = document.getElementById('tabMainBtn');
-            const tabStatusBtn = document.getElementById('tabStatusBtn');
             const tabMain = document.getElementById('tabMain');
-            const tabStatus = document.getElementById('tabStatus');
-
             tabMainBtn.onclick = function() {
                 tabMainBtn.classList.add('active');
-                tabStatusBtn.classList.remove('active');
                 tabMain.classList.add('active');
-                tabStatus.classList.remove('active');
-            }
-            tabStatusBtn.onclick = function() {
-                tabStatusBtn.classList.add('active');
-                tabMainBtn.classList.remove('active');
-                tabStatus.classList.add('active');
-                tabMain.classList.remove('active');
             }
         });
 
@@ -2094,33 +2066,6 @@
             });
         }
 
-        function setAccountStatus(status) {
-            const bar = document.getElementById('statusProgressFill');
-            const statusText = document.getElementById('accountStatusText');
-            const statusDesc = document.getElementById('statusDescription');
-            const steps = ['Good','Limited','Very Limited','At Risk','Banned'];
-            const colors = [
-                'linear-gradient(90deg,#10c95a,#2fd174)', // Good
-                'linear-gradient(90deg,#ffca29,#ffd66b)', // Limited
-                'linear-gradient(90deg,#f88407,#ff5f00)', // Very Limited
-                'linear-gradient(90deg,#e94434,#fc6a55)', // At Risk
-                'linear-gradient(90deg,#a10000,#570404)'  // Banned
-            ];
-            const descriptions = [
-                "Merci de respecter les règles de ToolCenter !",
-                "Vous ne pouvez plus utiliser certaines parties de ToolCenter. Vous risquez une suspension si vous enfreignez à nouveau les règles.",
-                "Vous ne pouvez plus utiliser la plupart des parties de ToolCenter. Votre compte pourrait être banni.",
-                "Votre compte est à risque. Vous ne pouvez plus utiliser ToolCenter tant que vous n'avez pas réglé le problème.",
-                "Votre compte est banni. Vous ne pouvez plus utiliser ToolCenter."
-            ];
-            const widths = ['10%','30%','50%','70%','100%'];
-            const idx = steps.indexOf(status);
-            if(idx === -1) return;
-            bar.style.width = widths[idx];
-            bar.style.background = colors[idx];
-            statusText.textContent = steps[idx];
-            statusDesc.textContent = descriptions[idx];
-        }
     </script>
 </body>
 </html>

--- a/frontend/account/logout.html
+++ b/frontend/account/logout.html
@@ -417,9 +417,15 @@
                         </a>
                     </li>
                     <li>
-                        <a href="/account/profile">
-                            <img src="/assets/personnaliser.png" alt="Profil" class="sidebar-icon">
-                            Personnalisation
+                        <a href="/account/moderation">
+                            <img src="/assets/security-icon.png" alt="Modération" class="sidebar-icon">
+                            Modération / Sanctions
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/account/support">
+                            <img src="/assets/support.png" alt="Support" class="sidebar-icon">
+                            Support / Tickets
                         </a>
                     </li>
                     <li>

--- a/frontend/account/moderation.html
+++ b/frontend/account/moderation.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ToolCenter - Modération</title>
+    <link rel="icon" href="/assets/tc_logo.webp" type="image/png">
+    <style>
+        body{font-family:'Inter',sans-serif;background:#0f0f13;color:#f0f0f5;margin:0;}
+        .container{display:flex;max-width:1200px;margin:30px auto;padding:0 5%;gap:25px;}
+        .sidebar{width:280px;background:#1a1a23;border-radius:16px;padding:16px 0;box-shadow:0 8px 30px rgba(0,0,0,0.2);border:1px solid rgba(255,255,255,0.08);}        
+        .sidebar-title{font-size:1rem;font-weight:600;opacity:.7;padding:0 20px 16px;border-bottom:1px solid rgba(255,255,255,0.08);margin-bottom:16px;}
+        .sidebar-menu{list-style:none;padding:0;margin:0;}
+        .sidebar-menu li{margin-bottom:4px;}
+        .sidebar-menu a{display:flex;align-items:center;padding:12px 20px;color:#f0f0f5;text-decoration:none;transition:background .2s;border-left:3px solid transparent;}
+        .sidebar-menu a.active,.sidebar-menu a:hover{background:rgba(255,255,255,0.05);border-color:#3000FF;}
+        .sidebar-icon{width:20px;height:20px;margin-right:12px;}
+        .main-content{flex:1;}
+        .profile-card{background:#1a1a23;border-radius:16px;box-shadow:0 8px 30px rgba(0,0,0,0.2);border:1px solid rgba(255,255,255,0.08);padding:30px;}
+        .skeleton{background:rgba(255,255,255,0.1);border-radius:8px;animation:pulse 1.5s infinite;}
+        .skeleton-text{height:16px;width:100%;margin-bottom:8px;}
+        .status-progress-bar{height:8px;background:#333;border-radius:4px;margin-bottom:16px;overflow:hidden;}
+        .status-progress{height:100%;width:0;background:linear-gradient(90deg,#10c95a,#2fd174);transition:width .5s;}
+        @keyframes pulse{0%{opacity:.6;}50%{opacity:1;}100%{opacity:.6;}}
+    </style>
+</head>
+<body>
+<div class="container">
+    <nav class="sidebar">
+        <div class="sidebar-title">Navigation</div>
+        <ul class="sidebar-menu">
+            <li><a href="/account"> <img src="/assets/account.png" class="sidebar-icon">Informations du compte</a></li>
+            <li><a href="/account/tools"><img src="/assets/code.png" class="sidebar-icon">Tools Publiés</a></li>
+            <li><a href="/account/moderation" class="active"><img src="/assets/security-icon.png" class="sidebar-icon">Modération / Sanctions</a></li>
+            <li><a href="/account/support"><img src="/assets/support.png" class="sidebar-icon">Support / Tickets</a></li>
+            <li><a href="/account/security"><img src="/assets/security-icon.png" class="sidebar-icon">Sécurité</a></li>
+            <li><a href="/account/preferences"><img src="/assets/preferences-icon.png" class="sidebar-icon">Préférences</a></li>
+            <li><a href="/account/confidentiality"><img src="/assets/privacy-icon.png" class="sidebar-icon">Confidentialité</a></li>
+            <li><a href="/account/notifications"><img src="/assets/newsletter.png" class="sidebar-icon">Notifications</a></li>
+            <li><a href="/account/logout"><img src="/assets/logout.png" class="sidebar-icon">Se déconnecter</a></li>
+        </ul>
+    </nav>
+    <div class="main-content">
+        <div class="profile-card">
+            <h2>Statut du compte</h2>
+            <div class="status-progress-bar"><div class="status-progress" id="statusFill"></div></div>
+            <p class="skeleton skeleton-text" style="width:60%" id="statusText"></p>
+            <h3 style="margin-top:30px;">Sanctions récentes</h3>
+            <div id="sanctionsList">
+                <p class="skeleton skeleton-text" style="width:80%"></p>
+                <p class="skeleton skeleton-text" style="width:70%"></p>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+let apiBaseURL="";
+function fetchData(){
+  const token=localStorage.getItem('token');
+  if(!token) return;
+  fetch('/ressources/utils/api').then(r=>r.text()).then(url=>{apiBaseURL=url;return fetch(`${apiBaseURL}/user/me`,{headers:{'Authorization':`Bearer ${token}`}});}).then(r=>r.json()).then(data=>{if(data.success){updateStatus(data.user);}});
+}
+function updateStatus(user){
+  const steps=['Good','Limited','Very Limited','At Risk','Banned'];
+  const widths=['10%','30%','50%','70%','100%'];
+  const idx=steps.indexOf(user.account_status);
+  document.getElementById('statusFill').style.width=widths[idx];
+  document.getElementById('statusText').textContent=`Statut: ${steps[idx]}`;
+  const list=document.getElementById('sanctionsList');
+  list.innerHTML='';
+  if(user.sanctions){
+    user.sanctions.forEach(s=>{
+      const p=document.createElement('p');
+      p.textContent=`${new Date(s.created_at).toLocaleDateString()} - ${s.type}: ${s.reason}`;
+      list.appendChild(p);
+    });
+  } else {
+    list.innerHTML='<p>Aucune sanction</p>';
+  }
+}
+document.addEventListener('DOMContentLoaded', fetchData);
+</script>
+</body>
+</html>

--- a/frontend/account/support.html
+++ b/frontend/account/support.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ToolCenter - Support</title>
+    <link rel="icon" href="/assets/tc_logo.webp" type="image/png">
+    <style>
+        body{font-family:'Inter',sans-serif;background:#0f0f13;color:#f0f0f5;margin:0;}
+        .container{display:flex;max-width:1200px;margin:30px auto;padding:0 5%;gap:25px;}
+        .sidebar{width:280px;background:#1a1a23;border-radius:16px;padding:16px 0;box-shadow:0 8px 30px rgba(0,0,0,0.2);border:1px solid rgba(255,255,255,0.08);}
+        .sidebar-title{font-size:1rem;font-weight:600;opacity:.7;padding:0 20px 16px;border-bottom:1px solid rgba(255,255,255,0.08);margin-bottom:16px;}
+        .sidebar-menu{list-style:none;padding:0;margin:0;}
+        .sidebar-menu li{margin-bottom:4px;}
+        .sidebar-menu a{display:flex;align-items:center;padding:12px 20px;color:#f0f0f5;text-decoration:none;transition:background .2s;border-left:3px solid transparent;}
+        .sidebar-menu a.active,.sidebar-menu a:hover{background:rgba(255,255,255,0.05);border-color:#3000FF;}
+        .sidebar-icon{width:20px;height:20px;margin-right:12px;}
+        .main-content{flex:1;}
+        .profile-card{background:#1a1a23;border-radius:16px;box-shadow:0 8px 30px rgba(0,0,0,0.2);border:1px solid rgba(255,255,255,0.08);padding:30px;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <nav class="sidebar">
+        <div class="sidebar-title">Navigation</div>
+        <ul class="sidebar-menu">
+            <li><a href="/account"> <img src="/assets/account.png" class="sidebar-icon">Informations du compte</a></li>
+            <li><a href="/account/tools"><img src="/assets/code.png" class="sidebar-icon">Tools Publiés</a></li>
+            <li><a href="/account/moderation"><img src="/assets/security-icon.png" class="sidebar-icon">Modération / Sanctions</a></li>
+            <li><a href="/account/support" class="active"><img src="/assets/support.png" class="sidebar-icon">Support / Tickets</a></li>
+            <li><a href="/account/security"><img src="/assets/security-icon.png" class="sidebar-icon">Sécurité</a></li>
+            <li><a href="/account/preferences"><img src="/assets/preferences-icon.png" class="sidebar-icon">Préférences</a></li>
+            <li><a href="/account/confidentiality"><img src="/assets/privacy-icon.png" class="sidebar-icon">Confidentialité</a></li>
+            <li><a href="/account/notifications"><img src="/assets/newsletter.png" class="sidebar-icon">Notifications</a></li>
+            <li><a href="/account/logout"><img src="/assets/logout.png" class="sidebar-icon">Se déconnecter</a></li>
+        </ul>
+    </nav>
+    <div class="main-content">
+        <div class="profile-card">
+            <h2>Support</h2>
+            <p>La gestion des tickets arrive bientôt.</p>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/frontend/account/tools.html
+++ b/frontend/account/tools.html
@@ -1161,9 +1161,15 @@
                         </a>
                     </li>
                     <li>
-                        <a href="/account/profile">
-                            <img src="/assets/personnaliser.png" alt="Profil" class="sidebar-icon">
-                            Personnalisation
+                        <a href="/account/moderation">
+                            <img src="/assets/security-icon.png" alt="Modération" class="sidebar-icon">
+                            Modération / Sanctions
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/account/support">
+                            <img src="/assets/support.png" alt="Support" class="sidebar-icon">
+                            Support / Tickets
                         </a>
                     </li>
                     <li>

--- a/frontend/admin/sanctions.html
+++ b/frontend/admin/sanctions.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ToolCenter - Sanctions</title>
+  <link rel="icon" href="/assets/tc_logo.webp" type="image/png">
+  <style>
+    body{font-family:'Poppins',sans-serif;background:#0f172a;color:#fff;margin:0;}
+    .admin-header{display:flex;align-items:center;justify-content:space-between;padding:20px;background:#1e293b;}
+    .admin-sidebar{width:230px;background:#1e293b;position:fixed;top:0;bottom:0;padding-top:80px;}
+    .sidebar-item{display:block;padding:12px 20px;color:#fff;text-decoration:none;border-left:3px solid transparent;}
+    .sidebar-item.active,.sidebar-item:hover{background:#111827;border-color:#6366f1;}
+    .admin-content{margin-left:250px;padding:30px;}
+    table{width:100%;border-collapse:collapse;margin-top:20px;}
+    th,td{padding:8px;border-bottom:1px solid rgba(255,255,255,0.1);}
+    th{text-align:left;}
+  </style>
+</head>
+<body>
+<header class="admin-header">
+  <h1>Gestion des sanctions</h1>
+</header>
+<div class="admin-sidebar">
+  <a href="/admin" class="sidebar-item">Tableau de bord</a>
+  <a href="/admin/users" class="sidebar-item">Utilisateurs</a>
+  <a href="/admin/sanctions" class="sidebar-item active">Sanctions</a>
+  <a href="/admin/logs" class="sidebar-item">Logs système</a>
+  <a href="/admin/tools" class="sidebar-item">Outils</a>
+</div>
+<main class="admin-content">
+  <table id="sanctions-table">
+    <thead>
+      <tr><th>Date</th><th>User ID</th><th>Type</th><th>Raison</th><th>Contestable</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</main>
+<script>
+fetch('/ressources/utils/api').then(r=>r.text()).then(api=>{
+  fetch(api+'/moderation/sanctions/'+new URLSearchParams(location.search).get('uid'),{credentials:'include'})
+    .then(r=>r.json()).then(data=>{if(data.success){const tb=document.querySelector('#sanctions-table tbody');data.sanctions.forEach(s=>{const tr=document.createElement('tr');tr.innerHTML=`<td>${new Date(s.created_at).toLocaleDateString()}</td><td>${s.sanction_id}</td><td>${s.type}</td><td>${s.reason}</td><td>${s.not_contestable? 'Non':'Oui'}</td>`;tb.appendChild(tr);});}});
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support moderation sanctions and appeals in API
- add DB tables for sanctions
- expose new moderation and support pages on frontend
- add admin sanctions panel
- update account pages navigation

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e053897608320a2169a847ba83986