### PR TITLE
Add private news password config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Because the world needed:
 
 All API variables live in `api/example config.json`.
 Adjust this file (ports, database, SMTP...) to match your environment.
+A new `private_news_password` field secures access to private news articles.
 
 ---
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -44,11 +44,12 @@ type Config struct {
 		SignInSecret string `json:"signin_secret"`
 		SignUpSecret string `json:"signup_secret"`
 	} `json:"turnstile"`
-        Cleanup struct {
-                CheckInterval int `json:"check_interval"`
-                GracePeriod   int `json:"grace_period"`
-        } `json:"cleanup"`
-       AvatarCooldownHours int `json:"avatar_cooldown_hours"`
+	Cleanup struct {
+		CheckInterval int `json:"check_interval"`
+		GracePeriod   int `json:"grace_period"`
+	} `json:"cleanup"`
+	PrivateNewsPassword string `json:"private_news_password"`
+	AvatarCooldownHours int    `json:"avatar_cooldown_hours"`
 }
 
 func Load(path string) error {

--- a/api/example config.json
+++ b/api/example config.json
@@ -36,5 +36,6 @@
     "check_interval": 600,
     "grace_period": 10
   },
-  "avatar_cooldown_hours": 24
+  "avatar_cooldown_hours": 24,
+  "private_news_password": "change-me"
 }

--- a/api/utils/privates_news.go
+++ b/api/utils/privates_news.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-)
 
-const privateNewsPassword = "27TND9274TND947T4O872O8724O8FT72O8F2FO"
+	"toolcenter/config"
+)
 
 var lastToken string
 var lastTokenExpiration time.Time
@@ -25,7 +25,7 @@ func loadPrivateArticles() ([]gin.H, error) {
 	if err != nil {
 		return nil, err
 	}
-	filePath := filepath.Join(exePath, "/utils/privates_articles.json")
+	filePath := filepath.Join(exePath, "utils", "privates_articles.json")
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func PrivateNewsHandler(c *gin.Context) {
 	}
 
 	if req.Password != "" {
-		if req.Password == privateNewsPassword {
+		if req.Password == config.Get().PrivateNewsPassword {
 			lastToken = generateToken(32)
 			lastTokenExpiration = time.Now().Add(24 * time.Hour)
 			c.JSON(http.StatusOK, gin.H{


### PR DESCRIPTION
## Summary
- expose `private_news_password` in example config and Config struct
- use configuration for private news password and fix article path
- document private news password in README

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6853fb0dce2083208ce85f863e9889fc