### PR TITLE
Add configurable CORS origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Because the world needed:
 All API variables live in `api/example config.json`.
 Adjust this file (ports, database, SMTP...) to match your environment.
 A new `private_news_password` field secures access to private news articles.
+Set `cors_allowed_origin` to control the `Access-Control-Allow-Origin` header.
 
 ---
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -16,9 +16,10 @@ type Config struct {
 	Port       int    `json:"port"`
 	Version    string `json:"version"`
 	URLVersion string `json:"URL_version"`
-	URLapi     string `json:"URL_api"`
-	URLweb     string `json:"URL_web"`
-	Debug      bool   `json:"debug"`
+       URLapi     string `json:"URL_api"`
+       URLweb     string `json:"URL_web"`
+       CorsAllowedOrigin string `json:"cors_allowed_origin"`
+       Debug      bool   `json:"debug"`
 	TimeZone   string `json:"time_zone"`
 	Logs       struct {
 		Enabled bool   `json:"enabled"`

--- a/api/example config.json
+++ b/api/example config.json
@@ -5,6 +5,7 @@
   "URL_version": "v1",
   "URL_api": "https://api.example.com",
   "URL_web": "https://example.com",
+  "cors_allowed_origin": "https://example.com",
   "debug": false,
   "time_zone": "UTC",
   "timezone": "",

--- a/api/main.go
+++ b/api/main.go
@@ -18,8 +18,12 @@ import (
 )
 
 func corsMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "https://tool-center.fr")
+        return func(c *gin.Context) {
+                origin := config.Get().CorsAllowedOrigin
+                if origin == "" {
+                        origin = "*"
+                }
+                c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Origin, Content-Type, Authorization")
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -97,5 +97,16 @@
         "isNew": true,
         "isPrivate": true,
         "tags": [""]
+    },
+    {
+        "id": 20,
+        "date": "2025-06-19",
+        "displayDate": "19/06/2025",
+        "title": "Option de configuration pour l'origine CORS",
+        "summary": "Ajout du champ cors_allowed_origin pour personnaliser l'en-t\u00eate CORS.",
+        "content": "La configuration permet d\u00e9sormais de d\u00e9finir l'origine autoris\u00e9e pour les requ\u00eates cross-origin.",
+        "isNew": true,
+        "isPrivate": true,
+        "tags": [""]
     }
 ]


### PR DESCRIPTION
## Summary
- add `cors_allowed_origin` in example config
- make `CorsAllowedOrigin` part of the configuration struct
- read the value in `corsMiddleware`
- document the new option in the README
- log this change in privates articles

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_685400ee39048320bcf9fe2e65cc0fa3