### PR TITLE
Add storage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ All API variables live in `api/example config.json`.
 Adjust this file (ports, database, SMTP...) to match your environment.
 A new `private_news_password` field secures access to private news articles.
 Set `cors_allowed_origin` to control the `Access-Control-Allow-Origin` header.
+Use the `storage` section to configure directories for avatars and tool images.
 
 ---
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -44,12 +44,16 @@ type Config struct {
 		SignInSecret string `json:"signin_secret"`
 		SignUpSecret string `json:"signup_secret"`
 	} `json:"turnstile"`
-	Cleanup struct {
-		CheckInterval int `json:"check_interval"`
-		GracePeriod   int `json:"grace_period"`
-	} `json:"cleanup"`
-	PrivateNewsPassword string `json:"private_news_password"`
-	AvatarCooldownHours int    `json:"avatar_cooldown_hours"`
+        Cleanup struct {
+                CheckInterval int `json:"check_interval"`
+                GracePeriod   int `json:"grace_period"`
+        } `json:"cleanup"`
+       Storage struct {
+               AvatarDir     string `json:"avatar_dir"`
+               ToolsImageDir string `json:"tools_image_dir"`
+       } `json:"storage"`
+        PrivateNewsPassword string `json:"private_news_password"`
+        AvatarCooldownHours int    `json:"avatar_cooldown_hours"`
 }
 
 func Load(path string) error {

--- a/api/example config.json
+++ b/api/example config.json
@@ -35,6 +35,10 @@
     "check_interval": 600,
     "grace_period": 10
   },
+  "storage": {
+    "avatar_dir": "/var/www/toolcenter/storage/avatars",
+    "tools_image_dir": "/var/www/toolcenter/storage/tools_images"
+  },
   "avatar_cooldown_hours": 24,
   "private_news_password": "change-me"
 }

--- a/api/scripts/tools/submit_tool.go
+++ b/api/scripts/tools/submit_tool.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/uuid"
 )
 
-const toolImageDir = "/var/www/toolcenter/storage/tools_images"
 const toolImageRelPath = "/tools_images/"
 
 func rnd() string {
@@ -112,10 +111,11 @@ func SubmitToolHandler(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "image invalide"})
 			return
 		}
-		img = imaging.Fill(img, 1200, 630, imaging.Center, imaging.Lanczos)
-		_ = os.MkdirAll(toolImageDir, 0755)
-		filename := rnd() + ".webp"
-		final := filepath.Join(toolImageDir, filename)
+               img = imaging.Fill(img, 1200, 630, imaging.Center, imaging.Lanczos)
+               dir := config.Get().Storage.ToolsImageDir
+               _ = os.MkdirAll(dir, 0755)
+               filename := rnd() + ".webp"
+               final := filepath.Join(dir, filename)
 		fp, err := os.Create(final)
 		if err != nil {
 			utils.LogActivity(c, uid, "submit_tool", false, "file create final")

--- a/api/scripts/user/avatar.go
+++ b/api/scripts/user/avatar.go
@@ -59,8 +59,8 @@ func UploadAvatar(c *gin.Context) {
 		return
 	}
 
-	if c.PostForm("avatar") == "delete" {
-		path := "/var/www/toolcenter/storage/avatars/" + uid + ".webp"
+       if c.PostForm("avatar") == "delete" {
+               path := filepath.Join(config.Get().Storage.AvatarDir, uid+".webp")
 		_ = os.Remove(path)
 		_, _ = db.Exec(`UPDATE users SET avatar_url = NULL, avatar_changed_at = NOW() WHERE user_id = ?`, uid)
 		utils.LogActivity(c, uid, "upload_avatar", true, "delete")
@@ -109,9 +109,9 @@ func UploadAvatar(c *gin.Context) {
 	}
 	img = imaging.Fill(img, 512, 512, imaging.Center, imaging.Lanczos)
 
-	dir := "/var/www/toolcenter/storage/avatars"
-	_ = os.MkdirAll(dir, 0755)
-	finalPath := dir + "/" + uid + ".webp"
+       dir := config.Get().Storage.AvatarDir
+       _ = os.MkdirAll(dir, 0755)
+       finalPath := filepath.Join(dir, uid+".webp")
 	fp, err := os.Create(finalPath)
 	if err != nil {
 		utils.LogActivity(c, uid, "upload_avatar", false, "create final")

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -108,5 +108,16 @@
         "isNew": true,
         "isPrivate": true,
         "tags": [""]
+    },
+    {
+        "id": 21,
+        "date": "2025-06-20",
+        "displayDate": "20/06/2025",
+        "title": "Chemins de stockage configurables",
+        "summary": "Ajout de la section storage pour choisir o\u00f9 sont enregistr\u00e9s avatars et images de tools.",
+        "content": "La configuration dispose maintenant d'une section `storage` permettant de personnaliser les dossiers de stockage des avatars et des images des tools.",
+        "isNew": true,
+        "isPrivate": true,
+        "tags": [""]
     }
 ]


### PR DESCRIPTION
## Summary
- add `Storage` section to API configuration
- update avatar and tools scripts to use `Storage` paths
- document new options in the README
- add storage fields in example config
- document feature in privates articles

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854757dc48c8320a375c9ba6bd22f25