### PR TITLE
Enhance admin ban controls and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - 💬 **Like, comment and share** other people's tools
 - 👤 **Manage your account**: avatar, security, statistics
 - 🛡️ A clean **moderation system**
+- ⏳ **Ban durations** and role restrictions for moderators
 - 📜 **Comprehensive logs** for users and admins
 - ⚡ A responsive design focused on usability
 

--- a/api/README.md
+++ b/api/README.md
@@ -210,9 +210,11 @@ curl -X POST https://api.tool-center.fr/api/user/update_password \
 
 | Méthode | URL | Description |
 | ------- | --- | ----------- |
-| `GET` | `/api/admin/user_list` | Liste des utilisateurs |
-| `POST` | `/api/admin/ban` | Bannir un utilisateur |
-| `POST` | `/api/admin/unban` | Débannir un utilisateur |
+| `GET` | `/api/admin/users` | Liste des utilisateurs |
+| `POST` | `/api/admin/users/{id}/ban` | Bannir un utilisateur |
+| `POST` | `/api/admin/users/{id}/unban` | Débannir un utilisateur |
+
+Le JSON du ban doit contenir `reason` et optionnellement `duration_hours` (0 ou omis = ban permanent). Les modérateurs ne peuvent bannir que les comptes "User".
 
 *(d'autres routes : `/api/reservations`, `/api/moderation`, etc. — voir le dossier `scripts/`)*
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -48,15 +48,18 @@ type Config struct {
 		CheckInterval int `json:"check_interval"`
 		GracePeriod   int `json:"grace_period"`
 	} `json:"cleanup"`
-	Storage struct {
-		AvatarDir     string `json:"avatar_dir"`
-		ToolsImageDir string `json:"tools_image_dir"`
-	} `json:"storage"`
-	Cooldowns struct {
-		EmailChangeDays    int `json:"email_change_days"`
-		UsernameChangeDays int `json:"username_change_days"`
-		ToolPostHours      int `json:"tool_post_hours"`
-		AvatarChangeHours  int `json:"avatar_change_hours"`
+        Storage struct {
+                AvatarDir     string `json:"avatar_dir"`
+                ToolsImageDir string `json:"tools_image_dir"`
+        } `json:"storage"`
+       Moderation struct {
+               MaxBanDays int `json:"max_ban_days"`
+       } `json:"moderation"`
+        Cooldowns struct {
+                EmailChangeDays    int `json:"email_change_days"`
+                UsernameChangeDays int `json:"username_change_days"`
+                ToolPostHours      int `json:"tool_post_hours"`
+                AvatarChangeHours  int `json:"avatar_change_hours"`
 	} `json:"cooldowns"`
 	PrivateNewsPassword string `json:"private_news_password"`
 }
@@ -67,13 +70,16 @@ func Load(path string) error {
 		return err
 	}
 	var cfg Config
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return err
-	}
-	mu.Lock()
-	Current = cfg
-	mu.Unlock()
-	return nil
+       if err := json.Unmarshal(data, &cfg); err != nil {
+               return err
+       }
+       if cfg.Moderation.MaxBanDays == 0 {
+               cfg.Moderation.MaxBanDays = 30
+       }
+       mu.Lock()
+       Current = cfg
+       mu.Unlock()
+       return nil
 }
 
 func Get() Config {

--- a/api/example config.json
+++ b/api/example config.json
@@ -39,6 +39,9 @@
     "avatar_dir": "/var/www/toolcenter/storage/avatars",
     "tools_image_dir": "/var/www/toolcenter/storage/tools_images"
   },
+  "moderation": {
+    "max_ban_days": 30
+  },
   "cooldowns": {
     "email_change_days": 30,
     "username_change_days": 30,

--- a/api/main.go
+++ b/api/main.go
@@ -149,8 +149,10 @@ func setupRoutes(r *gin.Engine) {
 	adminGroup.GET("/logs", admin.LogsHandler)
 	adminGroup.GET("/stats", admin.StatsHandler)
 
-	moderationGroup := api.Group("/moderation")
-	moderationGroup.Use(utils.RequireRole("Admin", "Moderator"))
+       moderationGroup := api.Group("/moderation")
+       moderationGroup.Use(utils.RequireRole("Admin", "Moderator"))
+       moderationGroup.POST("/users/:id/ban", admin.BanUserHandler)
+       moderationGroup.POST("/users/:id/unban", admin.UnbanUserHandler)
 
 	utilsGroup := api.Group("/utils")
 	utilsGroup.POST("/privates_news", utils.PrivateNewsHandler)

--- a/api/scripts/admin/ban_user.go
+++ b/api/scripts/admin/ban_user.go
@@ -1,17 +1,20 @@
 package admin
 
 import (
-	"net/http"
+        "database/sql"
+        "net/http"
+        "time"
 
-	"toolcenter/config"
-	"toolcenter/utils"
+        "toolcenter/config"
+        "toolcenter/utils"
 
-	"github.com/gin-gonic/gin"
-	_ "github.com/go-sql-driver/mysql"
+        "github.com/gin-gonic/gin"
+        _ "github.com/go-sql-driver/mysql"
 )
 
 type banRequest struct {
-	Reason string `json:"reason"`
+        Reason   string `json:"reason"`
+        Duration int    `json:"duration_hours"`
 }
 
 func BanUserHandler(c *gin.Context) {
@@ -22,35 +25,71 @@ func BanUserHandler(c *gin.Context) {
 		return
 	}
 
-	var req banRequest
-	if err := c.ShouldBindJSON(&req); err != nil || req.Reason == "" {
-		utils.LogActivity(c, "", "ban_user", false, "reason missing")
-		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "raison manquante"})
-		return
-	}
+       var req banRequest
+       if err := c.ShouldBindJSON(&req); err != nil || req.Reason == "" {
+               utils.LogActivity(c, "", "ban_user", false, "reason missing")
+               c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "raison manquante"})
+               return
+       }
 
-	moderatorID := c.GetString("user_id")
-	if moderatorID == targetID {
-		utils.LogActivity(c, moderatorID, "ban_user", false, "self ban")
-		c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "Impossible de se bannir soi-même"})
-		return
-	}
+       moderatorID := c.GetString("user_id")
+       moderatorRole := c.GetString("role")
+       if moderatorID == targetID {
+               utils.LogActivity(c, moderatorID, "ban_user", false, "self ban")
+               c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": "Impossible de se bannir soi-même"})
+               return
+       }
 
-	db, err := config.OpenDB()
-	if err != nil {
-		utils.LogActivity(c, moderatorID, "ban_user", false, "db open error")
-		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
-		return
-	}
-	defer db.Close()
+       db, err := config.OpenDB()
+       if err != nil {
+               utils.LogActivity(c, moderatorID, "ban_user", false, "db open error")
+               c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+               return
+       }
+       defer db.Close()
 
-	_, err = db.Exec(`UPDATE users SET account_status = 'Banned' WHERE user_id = ?`, targetID)
-	if err != nil {
-		utils.LogActivity(c, moderatorID, "ban_user", false, "update error")
-		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
-		return
-	}
-	_, _ = db.Exec(`INSERT INTO moderation_actions (moderator_id, user_id, action_type, reason) VALUES (?, ?, 'Ban', ?)`, moderatorID, targetID, req.Reason)
-	utils.LogActivity(c, moderatorID, "ban_user", true, "")
-	c.JSON(http.StatusOK, gin.H{"success": true})
+       var targetRole string
+       err = db.QueryRow(`SELECT role FROM users WHERE user_id = ?`, targetID).Scan(&targetRole)
+       if err == sql.ErrNoRows {
+               utils.LogActivity(c, moderatorID, "ban_user", false, "target not found")
+               c.JSON(http.StatusNotFound, gin.H{"success": false, "message": "utilisateur introuvable"})
+               return
+       }
+       if err != nil {
+               utils.LogActivity(c, moderatorID, "ban_user", false, "query error")
+               c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+               return
+       }
+
+       if moderatorRole == "Moderator" && targetRole != "User" {
+               utils.LogActivity(c, moderatorID, "ban_user", false, "forbidden")
+               c.JSON(http.StatusForbidden, gin.H{"success": false, "message": "action interdite"})
+               return
+       }
+       if moderatorRole == "Admin" && targetRole == "Admin" {
+               utils.LogActivity(c, moderatorID, "ban_user", false, "forbidden")
+               c.JSON(http.StatusForbidden, gin.H{"success": false, "message": "action interdite"})
+               return
+       }
+
+       maxHours := config.Get().Moderation.MaxBanDays * 24
+       if req.Duration < 0 || req.Duration > maxHours {
+               req.Duration = maxHours
+       }
+
+       var end sql.NullTime
+       if req.Duration > 0 {
+               end.Valid = true
+               end.Time = time.Now().Add(time.Duration(req.Duration) * time.Hour)
+       }
+
+       _, err = db.Exec(`UPDATE users SET account_status = 'Banned' WHERE user_id = ?`, targetID)
+       if err != nil {
+               utils.LogActivity(c, moderatorID, "ban_user", false, "update error")
+               c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+               return
+       }
+       _, _ = db.Exec(`INSERT INTO moderation_actions (moderator_id, user_id, action_type, reason, start_date, end_date) VALUES (?, ?, 'Ban', ?, NOW(), ?)`, moderatorID, targetID, req.Reason, end)
+       utils.LogActivity(c, moderatorID, "ban_user", true, "")
+       c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/api/scripts/admin/unban_user.go
+++ b/api/scripts/admin/unban_user.go
@@ -27,13 +27,14 @@ func UnbanUserHandler(c *gin.Context) {
 	}
 	defer db.Close()
 
-	_, err = db.Exec(`UPDATE users SET account_status = 'Good' WHERE user_id = ?`, uid)
-	if err != nil {
-		utils.LogActivity(c, moderatorID.(string), "unban_user", false, "update error")
-		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
-		return
-	}
-	_, _ = db.Exec(`INSERT INTO moderation_actions (moderator_id, user_id, action_type) VALUES (?, ?, 'Unban')`, moderatorID, uid)
+       _, err = db.Exec(`UPDATE users SET account_status = 'Good' WHERE user_id = ?`, uid)
+       if err != nil {
+               utils.LogActivity(c, moderatorID.(string), "unban_user", false, "update error")
+               c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+               return
+       }
+       _, _ = db.Exec(`UPDATE moderation_actions SET end_date=NOW() WHERE user_id=? AND action_type='Ban' AND (end_date IS NULL OR end_date>NOW()) ORDER BY action_date DESC LIMIT 1`, uid)
+       _, _ = db.Exec(`INSERT INTO moderation_actions (moderator_id, user_id, action_type) VALUES (?, ?, 'Unban')`, moderatorID, uid)
 	utils.LogActivity(c, moderatorID.(string), "unban_user", true, "")
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -141,5 +141,16 @@
         "isNew": true,
         "isPrivate": true,
         "tags": ["done"]
+    },
+    {
+        "id": 24,
+        "date": "2025-07-15",
+        "displayDate": "15/07/2025",
+        "title": "Am\u00e9liorations du panel admin",
+        "summary": "Dur\u00e9e de ban configurable et nouveaux indicateurs.",
+        "content": "Les administrateurs peuvent d\u00e9finir la dur\u00e9e d'un ban et voir rapidement si un utilisateur est v\u00e9rifi\u00e9 ou banni d\u00e9finitivement.",
+        "isNew": true,
+        "isPrivate": true,
+        "tags": ["done"]
     }
 ]

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -1148,6 +1148,7 @@
           <img src="https://tool-center.fr/assets/account.png" alt="User" class="user-avatar-lg" id="modal-avatar">
           <div class="user-details">
             <h2 class="user-name-lg" id="modal-user-name">Chargement...</h2>
+            <img src="/assets/verified.png" id="modal-verified" title="Vérifié" style="width:16px;height:16px;vertical-align:middle;display:none;">
             <span class="user-role role-user" id="modal-user-role">Utilisateur</span>
             <div class="user-stats">
               <div class="user-stat">
@@ -1159,11 +1160,12 @@
                 <div class="stat-label">Signalements</div>
               </div>
               <div class="user-stat">
-                <div class="stat-number" id="joined-date">--/--/----</div>
-                <div class="stat-label">Inscription</div>
-              </div>
+              <div class="stat-number" id="joined-date">--/--/----</div>
+              <div class="stat-label">Inscription</div>
             </div>
           </div>
+          <div id="ban-info" style="margin-top:8px;font-weight:600;color:#ef4444;display:none;"></div>
+        </div>
         </div>
 
         <div class="user-tabs">
@@ -1252,6 +1254,8 @@
       <div class="form-group ban-reason-group">
         <label for="ban-reason">Raison du ban</label>
         <textarea id="ban-reason" class="form-control" rows="3" placeholder="Indiquez la raison" style="resize: vertical;"></textarea>
+        <label for="ban-duration">Durée (heures, 0 = permanent)</label>
+        <input type="number" id="ban-duration" class="form-control" min="0" value="24">
       </div>
       <p id="unban-text" class="hidden">Voulez-vous vraiment débannir cet utilisateur ?</p>
     </div>
@@ -1519,7 +1523,7 @@
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify({ reason })
+          body: JSON.stringify({ reason, duration_hours: parseInt(document.getElementById('ban-duration').value, 10) || 0 })
         });
         
         if (!response.ok) {
@@ -1685,7 +1689,7 @@
       return statsContainer;
     }
 
-    function renderUsersTable(users) {
+    function renderUsersTable(users, page = 1, total = 0) {
       const container = document.createElement('div');
       container.innerHTML = `
       <h2 class="section-title">
@@ -1714,13 +1718,7 @@
           <!-- Users will be loaded here via JS -->
         </tbody>
         </table>
-        <div class="pagination">
-        <button class="page-btn"><i class="fas fa-chevron-left"></i></button>
-        <button class="page-btn active">1</button>
-        <button class="page-btn">2</button>
-        <button class="page-btn">3</button>
-        <button class="page-btn"><i class="fas fa-chevron-right"></i></button>
-        </div>
+        <div class="pagination" id="users-pagination"></div>
       </div>
       `;
       
@@ -1808,18 +1806,30 @@
       
       const searchInput = container.querySelector('#user-search');
       let searchTimeout;
-      
+
       searchInput.addEventListener('input', () => {
       clearTimeout(searchTimeout);
       searchTimeout = setTimeout(() => {
-        loadUsers(searchInput.value);
+        loadUsers(searchInput.value, 1);
       }, 500);
+      });
+
+      const pag = container.querySelector('#users-pagination');
+      const maxPage = Math.max(1, Math.ceil(total / 10));
+      pag.innerHTML = `
+        <button class="page-btn" ${page<=1?'disabled':''} data-page="${page-1}"><i class="fas fa-chevron-left"></i></button>
+        <span class="page-info">Page ${page}/${maxPage}</span>
+        <button class="page-btn" ${page>=maxPage?'disabled':''} data-page="${page+1}"><i class="fas fa-chevron-right"></i></button>`;
+      pag.querySelectorAll('button').forEach(btn=>{
+        btn.addEventListener('click',()=>{
+          const p=parseInt(btn.getAttribute('data-page')); if(p>=1&&p<=maxPage){ loadUsers(searchInput.value,p); }
+        });
       });
       
       return container;
     }
 
-    function renderSystemLogs(logs) {
+    function renderSystemLogs(logs, page = 1, total = 0) {
       const container = document.createElement('div');
       container.innerHTML = `
         <h2 class="section-title">
@@ -1848,13 +1858,7 @@
               <!-- Logs will be loaded here via JS -->
             </tbody>
           </table>
-          <div class="pagination">
-            <button class="page-btn"><i class="fas fa-chevron-left"></i></button>
-            <button class="page-btn active">1</button>
-            <button class="page-btn">2</button>
-            <button class="page-btn">3</button>
-            <button class="page-btn"><i class="fas fa-chevron-right"></i></button>
-          </div>
+          <div class="pagination" id="logs-pagination"></div>
         </div>
       `;
       
@@ -1881,12 +1885,24 @@
       
       const searchInput = container.querySelector('#logs-search');
       let searchTimeout;
-      
+
       searchInput.addEventListener('input', () => {
         clearTimeout(searchTimeout);
         searchTimeout = setTimeout(() => {
-          loadSystemLogs(searchInput.value);
+          loadSystemLogs(1);
         }, 500);
+      });
+
+      const pag = container.querySelector('#logs-pagination');
+      const maxPage = Math.max(1, Math.ceil(total / 10));
+      pag.innerHTML = `
+        <button class="page-btn" ${page<=1?'disabled':''} data-page="${page-1}"><i class="fas fa-chevron-left"></i></button>
+        <span class="page-info">Page ${page}/${maxPage}</span>
+        <button class="page-btn" ${page>=maxPage?'disabled':''} data-page="${page+1}"><i class="fas fa-chevron-right"></i></button>`;
+      pag.querySelectorAll('button').forEach(btn=>{
+        btn.addEventListener('click',()=>{
+          const p=parseInt(btn.getAttribute('data-page')); if(p>=1&&p<=maxPage){ loadSystemLogs(p); }
+        });
       });
       
       return container;
@@ -1945,6 +1961,12 @@
       const user = data.user;
       
       document.getElementById('modal-user-name').textContent = user.username;
+      const verifiedIcon = document.getElementById('modal-verified');
+      if (user.is_verified) {
+        verifiedIcon.style.display = 'inline-block';
+      } else {
+        verifiedIcon.style.display = 'none';
+      }
       document.getElementById('modal-avatar').src = user.avatar || '/assets/account.png';
       
       const roleBadge = document.getElementById('modal-user-role');
@@ -1958,6 +1980,20 @@
       document.getElementById('tools-count').textContent = user.toolsCount || 0;
       document.getElementById('reports-count').textContent = user.reportsCount || 0;
       document.getElementById('joined-date').textContent = new Date(user.createdAt).toLocaleDateString();
+      const banInfo = document.getElementById('ban-info');
+      if (user.status === 'Banned') {
+        if (user.ban_permanent) {
+          banInfo.textContent = 'Banni définitivement';
+        } else if (user.ban_until) {
+          const end = new Date(user.ban_until);
+          const diff = Math.max(0, end - Date.now());
+          const hours = Math.ceil(diff / 3600000);
+          banInfo.textContent = `Ban restant: ${hours}h`;
+        }
+        banInfo.style.display = 'block';
+      } else {
+        banInfo.style.display = 'none';
+      }
       
       document.getElementById('username').value = user.username;
       document.getElementById('email').value = user.email;
@@ -1998,7 +2034,7 @@
       }
     }
 
-    async function loadUsers(search = '') {
+    async function loadUsers(search = '', page = 1) {
       const existing = document.getElementById(SECTION_IDS.users);
       if (existing) existing.remove();
 
@@ -2007,8 +2043,8 @@
       adminContent.appendChild(placeholder);
       showLoadingSkeleton('users');
 
-      const { users } = await fetchUsers(search);
-      const usersElement = renderUsersTable(users);
+      const { users, total } = await fetchUsers(search, page);
+      const usersElement = renderUsersTable(users, page, total);
       usersElement.id = SECTION_IDS.users;
 
       if (!document.querySelector('.stats-cards')) {
@@ -2027,8 +2063,8 @@
       adminContent.appendChild(placeholder);
       showLoadingSkeleton('logs');
 
-      const { logs } = await fetchSystemLogs(page);
-      const logsElement = renderSystemLogs(logs);
+      const { logs, total } = await fetchSystemLogs(page);
+      const logsElement = renderSystemLogs(logs, page, total);
       logsElement.id = SECTION_IDS.logs;
 
       if (!document.querySelector('.stats-cards')) {
@@ -2139,6 +2175,7 @@
       function closeBan() {
         banModal.classList.remove('active');
         banReasonInput.value = '';
+        document.getElementById('ban-duration').value = '24';
       }
 
       closeBanModal.addEventListener('click', closeBan);


### PR DESCRIPTION
## Summary
- add moderation settings in config
- support ban duration and role restrictions
- expose ban details in admin user details
- add pagination info for users and logs
- extend admin panel UI to handle ban duration and show verification
- update documentation and articles

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856035d14588320896b2ea4bf9667f4