### PR TITLE
Add 2FA session management and cleanup security page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - 💬 **Like, comment and share** other people's tools
 - 👤 **Manage your account**: avatar, security, statistics
 - 🔐 **Two-factor authentication** with Google Authenticator
+- 🖥️ **Manage active sessions** in your security settings
 - 🛡️ A clean **moderation system**
 - ⏳ **Ban durations** and role restrictions for moderators
 - 📜 **Comprehensive logs** for users and admins
@@ -61,6 +62,9 @@ The `moderation` section now includes `auto_unban` to automatically lift tempora
 - `POST /v{n}/admin/logs/clear` – clear all activity logs
 - `GET /v{n}/admin/users/{id}/tools` – list tools of a specific user
 - `GET /v{n}/admin/users/{id}/ban` – get last ban reason
+- `GET /v{n}/auth/sessions` – list active sessions
+- `DELETE /v{n}/auth/sessions` – revoke all other sessions
+- `DELETE /v{n}/auth/sessions/{id}` – revoke a specific session
 
 ---
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
+	github.com/mssola/user_agent v0.6.0 // indirect
 	golang.org/x/image v0.27.0 // indirect
 )
 

--- a/api/go.sum
+++ b/api/go.sum
@@ -57,6 +57,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mssola/user_agent v0.6.0 h1:uwPR4rtWlCHRFyyP9u2KOV0u8iQXmS7Z7feTrstQwk4=
+github.com/mssola/user_agent v0.6.0/go.mod h1:TTPno8LPY3wAIEKRpAtkdMT0f8SE24pLRGPahjCH4uw=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/api/main.go
+++ b/api/main.go
@@ -123,6 +123,9 @@ func setupRoutes(r *gin.Engine) {
 	authGroup.POST("/login", auth.LoginHandler)
 	authGroup.POST("/register", auth.RegisterHandler)
 	authGroup.POST("/logout", auth.LogoutHandler)
+	authGroup.GET("/sessions", auth.GetSessionsHandler)
+	authGroup.DELETE("/sessions", auth.DeleteAllSessionsHandler)
+	authGroup.DELETE("/sessions/:id", auth.DeleteSessionHandler)
 
 	userGroup := api.Group("/user")
 	userGroup.GET("/verify_email", user.VerifyEmailHandler)

--- a/api/scripts/auth/login.go
+++ b/api/scripts/auth/login.go
@@ -140,7 +140,7 @@ func LoginHandler(c *gin.Context) {
 	hash := sha256.Sum256([]byte(token))
 	tokenHash := hex.EncodeToString(hash[:])
 
-	_, err = db.Exec(`
+	res, err := db.Exec(`
 INSERT INTO user_tokens (user_id, token, device_info, expires_at)
 VALUES (?, ?, ?, ?)`,
 		uid, tokenHash,
@@ -155,10 +155,12 @@ VALUES (?, ?, ?, ?)`,
 		})
 		return
 	}
+	sessionID, _ := res.LastInsertId()
 
 	utils.LogActivity(c, uid, "login", true, "")
 	c.JSON(http.StatusOK, gin.H{
-		"success": true,
-		"token":   token,
+		"success":    true,
+		"token":      token,
+		"session_id": sessionID,
 	})
 }

--- a/api/scripts/auth/sessions.go
+++ b/api/scripts/auth/sessions.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"time"
+
+	"toolcenter/config"
+	"toolcenter/utils"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/mssola/user_agent"
+)
+
+type sessionInfo struct {
+	ID         int64     `json:"id"`
+	DeviceType string    `json:"device_type"`
+	OS         string    `json:"os"`
+	Browser    string    `json:"browser"`
+	Location   string    `json:"location"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+func currentTokenHash(c *gin.Context) string {
+	header := c.GetHeader("Authorization")
+	if !strings.HasPrefix(header, "Bearer ") {
+		return ""
+	}
+	raw := strings.TrimPrefix(header, "Bearer ")
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+func GetSessionsHandler(c *gin.Context) {
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{RequireToken: true, RequireVerified: true, RequireNotBanned: true})
+	if err != nil {
+		code := http.StatusInternalServerError
+		switch err {
+		case utils.ErrMissingToken, utils.ErrInvalidToken, utils.ErrExpiredToken:
+			code = http.StatusUnauthorized
+		case utils.ErrEmailNotVerified, utils.ErrAccountBanned:
+			code = http.StatusForbidden
+		}
+		c.JSON(code, gin.H{"success": false, "message": err.Error()})
+		return
+	}
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT token_id, token, device_info, created_at FROM user_tokens WHERE user_id=? ORDER BY created_at DESC`, uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer rows.Close()
+
+	sessions := make([]sessionInfo, 0)
+	for rows.Next() {
+		var id int64
+		var tokenHash, deviceInfo string
+		var createdAt time.Time
+		if err := rows.Scan(&id, &tokenHash, &deviceInfo, &createdAt); err != nil {
+			continue
+		}
+		parts := strings.SplitN(deviceInfo, " | ", 2)
+		uaStr := parts[0]
+		ua := user_agent.New(uaStr)
+		browser, _ := ua.Browser()
+		deviceType := "desktop"
+		if ua.Mobile() {
+			deviceType = "mobile"
+		}
+		sessions = append(sessions, sessionInfo{
+			ID:         id,
+			DeviceType: deviceType,
+			OS:         ua.OS(),
+			Browser:    browser,
+			Location:   "",
+			CreatedAt:  createdAt,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "sessions": sessions})
+}
+
+func DeleteSessionHandler(c *gin.Context) {
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{RequireToken: true, RequireVerified: true, RequireNotBanned: true})
+	if err != nil {
+		code := http.StatusInternalServerError
+		switch err {
+		case utils.ErrMissingToken, utils.ErrInvalidToken, utils.ErrExpiredToken:
+			code = http.StatusUnauthorized
+		case utils.ErrEmailNotVerified, utils.ErrAccountBanned:
+			code = http.StatusForbidden
+		}
+		c.JSON(code, gin.H{"success": false, "message": err.Error()})
+		return
+	}
+
+	id := c.Param("id")
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	res, err := db.Exec(`DELETE FROM user_tokens WHERE token_id=? AND user_id=?`, id, uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"success": false, "message": "Session inconnue"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+func DeleteAllSessionsHandler(c *gin.Context) {
+	uid, _, _, _, err := utils.Check(c, utils.CheckOpts{RequireToken: true, RequireVerified: true, RequireNotBanned: true})
+	if err != nil {
+		code := http.StatusInternalServerError
+		switch err {
+		case utils.ErrMissingToken, utils.ErrInvalidToken, utils.ErrExpiredToken:
+			code = http.StatusUnauthorized
+		case utils.ErrEmailNotVerified, utils.ErrAccountBanned:
+			code = http.StatusForbidden
+		}
+		c.JSON(code, gin.H{"success": false, "message": err.Error()})
+		return
+	}
+
+	currentHash := currentTokenHash(c)
+
+	db, err := config.OpenDB()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	defer db.Close()
+
+	if currentHash != "" {
+		_, _ = db.Exec(`DELETE FROM user_tokens WHERE user_id=? AND token<>?`, uid, currentHash)
+	} else {
+		_, _ = db.Exec(`DELETE FROM user_tokens WHERE user_id=?`, uid)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -219,5 +219,18 @@
     "tags": [
       ""
     ]
+  },
+  {
+    "id": 28,
+    "date": "2025-09-20",
+    "displayDate": "20/09/2025",
+    "title": "Gestion des sessions actives",
+    "summary": "Vue d'ensemble des sessions et possibilité de les révoquer.",
+    "content": "La page sécurité affiche désormais toutes vos sessions actives. Vous pouvez déconnecter un appareil ou toutes vos sessions en un clic.",
+    "isNew": true,
+    "isPrivate": true,
+    "tags": [
+      ""
+    ]
   }
 ]

--- a/frontend/account/security.html
+++ b/frontend/account/security.html
@@ -421,282 +421,6 @@
             border: 1px solid var(--light-border);
         }
 
-        .tools-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 30px;
-        }
-
-        .tools-title {
-            font-size: 1.8rem;
-            font-weight: 700;
-            background: linear-gradient(90deg, var(--primary-color), #6a00ff);
-            background-clip: text;
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            display: inline-block;
-        }
-
-        .light-mode .tools-title {
-            background: linear-gradient(90deg, var(--primary-color), #6a00ff);
-            background-clip: text;
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-        }
-
-        .tools-subtitle {
-            color: #aaa;
-            font-size: 1rem;
-            margin-top: 8px;
-        }
-
-        .add-tool-btn {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            padding: 12px 20px;
-            background-color: var(--primary-color);
-            color: white;
-            border: none;
-            border-radius: var(--radius-sm);
-            font-weight: 600;
-            cursor: pointer;
-            transition: var(--transition);
-        }
-
-        .add-tool-btn:hover {
-            background-color: var(--primary-hover);
-            transform: translateY(-2px);
-        }
-
-        .add-tool-icon {
-            width: 18px;
-            height: 18px;
-        }
-
-        .tools-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-            gap: 20px;
-            margin-top: 20px;
-        }
-
-        .tools-grid.hidden {
-            display: none !important;
-        }
-
-        .no-tools {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            text-align: center;
-            padding: 60px 20px;
-            background-color: rgba(255, 255, 255, 0.03);
-            border-radius: var(--radius);
-            border: 1px dashed var(--dark-border);
-        }
-        
-        .no-tools.hidden {
-            display: none !important;
-        }
-
-        .light-mode .no-tools {
-            background-color: rgba(0, 0, 0, 0.03);
-            border: 1px dashed var(--light-border);
-        }
-
-        .no-tools-icon {
-            width: 60px;
-            height: 60px;
-            margin-bottom: 20px;
-            opacity: 0.6;
-        }
-
-        .no-tools-title {
-            font-size: 1.3rem;
-            font-weight: 600;
-            margin-bottom: 10px;
-        }
-
-        .no-tools-text {
-            color: #aaa;
-            margin-bottom: 20px;
-            max-width: 400px;
-        }
-
-        .tool-card {
-            background-color: rgba(255, 255, 255, 0.03);
-            border-radius: var(--radius);
-            padding: 20px;
-            transition: var(--transition);
-            border: 1px solid var(--dark-border);
-            position: relative;
-            overflow: hidden;
-        }
-
-        .light-mode .tool-card {
-            background-color: rgba(0, 0, 0, 0.03);
-            border: 1px solid var(--light-border);
-        }
-
-        .tool-card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
-            border-color: var(--primary-color);
-        }
-
-        .tool-card::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 3px;
-            height: 100%;
-            background-color: var(--primary-color);
-            opacity: 0;
-            transition: var(--transition);
-        }
-
-        .tool-card:hover::before {
-            opacity: 1;
-        }
-
-        .tool-status {
-            position: absolute;
-            top: 20px;
-            right: 20px;
-            padding: 4px 10px;
-            border-radius: 20px;
-            font-size: 0.75rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-
-        .status-published {
-            background-color: rgba(16, 201, 90, 0.15);
-            color: var(--success-color);
-        }
-
-        .status-pending {
-            background-color: rgba(255, 202, 41, 0.15);
-            color: var(--warning-color);
-        }
-
-        .status-rejected {
-            background-color: rgba(233, 68, 52, 0.15);
-            color: var(--danger-color);
-        }
-
-        .status-draft {
-            background-color: rgba(59, 130, 246, 0.15);
-            color: var(--info-color);
-        }
-
-        .tool-image {
-            width: 100%;
-            height: 160px;
-            object-fit: cover;
-            border-radius: var(--radius-sm);
-            margin-bottom: 15px;
-            background-color: rgba(255, 255, 255, 0.05);
-        }
-
-        .tool-title {
-            font-size: 1.2rem;
-            font-weight: 600;
-            margin-bottom: 8px;
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            line-clamp: 2;
-            -webkit-box-orient: vertical;
-            overflow: hidden;
-        }
-
-        .tool-description {
-            color: #aaa;
-            font-size: 0.9rem;
-            margin-bottom: 15px;
-            display: -webkit-box;
-            -webkit-line-clamp: 3;
-            line-clamp: 3;
-            -webkit-box-orient: vertical;
-            overflow: hidden;
-        }
-
-        .tool-meta {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-top: 15px;
-            padding-top: 15px;
-            border-top: 1px solid var(--dark-border);
-        }
-
-        .light-mode .tool-meta {
-            border-top: 1px solid var(--light-border);
-        }
-
-        .tool-date {
-            font-size: 0.8rem;
-            color: #777;
-        }
-
-        .tool-actions {
-            display: flex;
-            gap: 8px;
-        }
-
-        .tool-action-btn {
-            width: 32px;
-            height: 32px;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background-color: rgba(255, 255, 255, 0.05);
-            border: none;
-            cursor: pointer;
-            transition: var(--transition);
-        }
-
-        .light-mode .tool-action-btn {
-            background-color: rgba(0, 0, 0, 0.05);
-        }
-
-        .tool-action-btn:hover {
-            background-color: rgba(255, 255, 255, 0.1);
-            transform: scale(1.1);
-        }
-
-        .light-mode .tool-action-btn:hover {
-            background-color: rgba(0, 0, 0, 0.1);
-        }
-
-        .tool-action-icon {
-            width: 16px;
-            height: 16px;
-            opacity: 0.7;
-            transition: var(--transition);
-        }
-
-        .tool-action-btn:hover .tool-action-icon {
-            opacity: 1;
-        }
-
-        .edit-icon {
-            filter: invert(50%) sepia(99%) saturate(2476%) hue-rotate(210deg) brightness(100%) contrast(101%);
-        }
-
-        .delete-icon {
-            filter: invert(26%) sepia(86%) saturate(2107%) hue-rotate(340deg) brightness(92%) contrast(92%);
-        }
-
-        .view-icon {
-            filter: invert(52%) sepia(98%) saturate(356%) hue-rotate(71deg) brightness(95%) contrast(87%);
-        }
 
         .modal-overlay {
             position: fixed;
@@ -732,13 +456,6 @@
             border: 1px solid var(--dark-border);
         }
 
-        #toolModalError.hidden {
-            display: none !important;
-        }
-
-        #toolModalSuccess.hidden {
-            display: none !important;
-        }
 
         .light-mode .modal {
             background-color: var(--light-card);
@@ -1462,33 +1179,35 @@
             </div>
         </div>
 
-        <div class="modal-overlay" id="deleteModal">
-            <div class="modal">
-                <div class="modal-header">
-                    <h3 class="modal-title">Confirmer la suppression</h3>
-                    <button class="modal-close" id="closeDeleteModal">
-                        <img src="/assets/croix.png" alt="Fermer" class="modal-close-icon">
-                    </button>
+    </div>
+
+    <div class="modal-overlay" id="twoFAModal">
+        <div class="modal">
+            <div class="modal-header">
+                <h3 class="modal-title">Activer l'authentification à deux facteurs</h3>
+                <button class="modal-close" id="close2FAModal">
+                    <img src="/assets/croix.png" alt="Fermer" class="modal-close-icon">
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>Scannez ce QR Code avec Google Authenticator puis entrez le code généré.</p>
+                <div id="qrCodeContainer" style="text-align:center;margin:20px 0;"></div>
+                <input type="text" id="twoFACodeInput" class="form-input" placeholder="Code 2FA">
+                <div id="twoFAError" class="error-message" style="display:none;margin-top:10px;">
+                    <img src="/assets/error.png" alt="Erreur" class="error-icon">
+                    <span id="twoFAErrorText"></span>
                 </div>
-                <div class="modal-body">
-                    <p>Êtes-vous sûr de vouloir supprimer ce tool ? Cette action est irréversible.</p>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-secondary" id="cancelDeleteModal">Annuler</button>
-                    <button class="btn btn-danger" id="confirmDeleteModal">
-                        <span class="spinner hidden" id="deleteSpinner"></span>
-                        <span id="deleteText">Supprimer</span>
-                    </button>
-                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" id="cancel2FAModal">Annuler</button>
+                <button class="btn btn-primary" id="confirm2FAModal">Valider</button>
             </div>
         </div>
     </div>
 
     <script>
         let apiBaseURL = "";
-        let currentUserTools = [];
         let twoFactorEnabled = false;
-        let currentEditingToolId = null;
         
         document.addEventListener('DOMContentLoaded', () => {
             const token = localStorage.getItem('token');
@@ -1502,18 +1221,11 @@
                     .then(res => res.text())
                     .then(url => {
                         apiBaseURL = url;
-                        if (document.getElementById('toolsGrid')) {
-                            return fetchUserTools();
-                        }
                     })
                     .then(() => {
                         initTheme();
                         initSecurityButtons();
                         checkTwoFactor();
-                        if (document.getElementById('addToolBtn')) {
-                            initToolModal();
-                            initDeleteModal();
-                        }
                     })
                     .catch(error => {
                         console.error('Erreur:', error);
@@ -1577,144 +1289,6 @@
             successContainer.classList.remove('hidden');
         }
         
-        function fetchUserTools() {
-            const token = localStorage.getItem('token');
-            const skeletonGrid = document.getElementById('skeletonGrid');
-            const noTools = document.getElementById('noTools');
-            const toolsGrid = document.getElementById('toolsGrid');
-
-            if (!skeletonGrid || !noTools || !toolsGrid) {
-                return Promise.resolve();
-            }
-            
-            return fetch(`${apiBaseURL}/tools/me`, {
-                method: 'GET',
-                headers: {
-                    'Authorization': `Bearer ${token}`
-                }
-            })
-            .then(response => {
-                if (!response.ok) {
-                    if (response.status === 401) {
-                        localStorage.removeItem('token');
-                        throw new Error("Votre session a expiré. Veuillez vous reconnecter.");
-                    }
-                    throw new Error('Erreur lors de la récupération des tools');
-                }
-                return response.json();
-            })
-            .then(data => {
-                if (data.success) {
-                    currentUserTools = data.tools;
-                    
-                    skeletonGrid.classList.add('hidden');
-                    
-                    noTools.classList.add('hidden');
-                    toolsGrid.classList.add('hidden');
-
-                    if (data.tools.length === 0) {
-                        noTools.classList.remove('hidden');
-                    } else {
-                        toolsGrid.classList.remove('hidden');
-                        renderTools(data.tools);
-                    }
-                                    
-                    return data;
-                } else {
-                    throw new Error(data.message || "Erreur lors de la récupération des tools");
-                }
-            });
-        }
-        
-        function renderTools(tools) {
-            const toolsGrid = document.getElementById('toolsGrid');
-            toolsGrid.innerHTML = '';
-            
-            tools.forEach(tool => {
-                const toolCard = document.createElement('div');
-                toolCard.className = 'tool-card';
-                
-                const createdAt = new Date(tool.created_at);
-                const formattedDate = createdAt.toLocaleDateString('fr-FR', {
-                    day: 'numeric',
-                    month: 'short',
-                    year: 'numeric'
-                });
-                
-                let statusText = '';
-                let statusClass = '';
-                
-                switch (tool.status && tool.status.toLowerCase()) {
-                    case 'published':
-                        statusText = 'Publié';
-                        statusClass = 'status-published';
-                        break;
-                    case 'moderated':
-                        statusText = 'En attente';
-                        statusClass = 'status-pending';
-                        break;
-                    case 'hidden':
-                        statusText = 'REFUSE';
-                        statusClass = 'status-rejected';
-                        break;
-                    default:
-                        statusText = tool.status || 'INCONNU';
-                        statusClass = 'status-draft';
-                        break;
-                }
-                
-                const imageUrl = tool.thumbnail_url || '/assets/default-tool.png';
-                const toolId = tool.tool_id || tool.id;
-                
-                toolCard.innerHTML = `
-                    <div class="tool-status ${statusClass}">${statusText}</div>
-                    <img src="${imageUrl}" alt="${tool.title}" class="tool-image">
-                    <h3 class="tool-title">${tool.title}</h3>
-                    <p class="tool-description">${tool.description}</p>
-                    <div class="tool-meta">
-                        <span class="tool-date">${formattedDate}</span>
-                        <div class="tool-actions">
-                            <button class="tool-action-btn view-tool" data-id="${toolId}">
-                                <img src="/assets/show.png" alt="Voir" class="tool-action-icon view-icon">
-                            </button>
-                            <button class="tool-action-btn edit-tool" data-id="${toolId}">
-                                <img src="/assets/edit-icon.png" alt="Éditer" class="tool-action-icon edit-icon">
-                            </button>
-                            <button class="tool-action-btn delete-tool" data-id="${toolId}">
-                                <img src="/assets/trash.png" alt="Supprimer" class="tool-action-icon delete-icon">
-                            </button>
-                        </div>
-                    </div>
-                `;
-                
-                toolsGrid.appendChild(toolCard);
-            });
-            
-            document.querySelectorAll('.edit-tool').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    const toolId = e.currentTarget.getAttribute('data-id');
-                    openEditToolModal(toolId);
-                });
-            });
-            
-            document.querySelectorAll('.delete-tool').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    const toolId = e.currentTarget.getAttribute('data-id');
-                    openDeleteModal(toolId);
-                });
-            });
-            
-            document.querySelectorAll('.view-tool').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    const toolId = e.currentTarget.getAttribute('data-id');
-                    const tool = currentUserTools.find(t => t.id === toolId || t.tool_id === toolId);
-
-                    if (tool) {
-                        window.open(tool.url, '_blank');
-                    }
-                });
-            });
-        }
         
         function initTheme() {
             const themeSwitcher = document.getElementById("theme-switcher");
@@ -1781,25 +1355,49 @@
 
         function handle2FA() {
             const token = localStorage.getItem('token');
+            const modal = document.getElementById('twoFAModal');
+            const qrContainer = document.getElementById('qrCodeContainer');
+            const codeInput = document.getElementById('twoFACodeInput');
+            const errorBox = document.getElementById('twoFAError');
+            const errorText = document.getElementById('twoFAErrorText');
+
+            function closeModal() {
+                modal.classList.remove('active');
+                codeInput.value = '';
+                errorBox.style.display = 'none';
+            }
+
+            document.getElementById('close2FAModal').onclick = closeModal;
+            document.getElementById('cancel2FAModal').onclick = closeModal;
+
             if (!twoFactorEnabled) {
                 fetch(`${apiBaseURL}/user/2fa/setup`, { headers: { 'Authorization': `Bearer ${token}` } })
                 .then(r => r.json())
                 .then(data => {
                     if (data.success) {
-                        const code = prompt('Scannez le QR code puis saisissez le code\n' + data.secret);
-                        if (!code) return;
-                        fetch(`${apiBaseURL}/user/enable_2fa`, {
-                            method: 'POST',
-                            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ secret: data.secret, code: code.trim() })
-                        }).then(resp => resp.json()).then(res => {
-                            if (res.success) {
-                                alert('2FA activée');
-                                twoFactorEnabled = true;
-                                document.getElementById('enable2faBtn').textContent = 'Désactiver';
-                            } else { alert(res.message || 'Erreur'); }
-                        });
-                    } else { alert(data.message || 'Erreur'); }
+                        qrContainer.innerHTML = `<img src="data:image/png;base64,${data.qr_code}" alt="QR Code">`;
+                        modal.classList.add('active');
+                        document.getElementById('confirm2FAModal').onclick = () => {
+                            const code = codeInput.value.trim();
+                            if (!code) return;
+                            fetch(`${apiBaseURL}/user/enable_2fa`, {
+                                method: 'POST',
+                                headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ secret: data.secret, code })
+                            }).then(resp => resp.json()).then(res => {
+                                if (res.success) {
+                                    twoFactorEnabled = true;
+                                    document.getElementById('enable2faBtn').textContent = 'Désactiver';
+                                    closeModal();
+                                } else {
+                                    errorText.textContent = res.message || 'Erreur';
+                                    errorBox.style.display = 'flex';
+                                }
+                            });
+                        };
+                    } else {
+                        showError(data.message || 'Erreur');
+                    }
                 });
             } else {
                 const code = prompt('Code 2FA pour désactiver');
@@ -1810,7 +1408,6 @@
                     body: JSON.stringify({ code: code.trim() })
                 }).then(r => r.json()).then(res => {
                     if (res.success) {
-                        alert('2FA désactivée');
                         twoFactorEnabled = false;
                         document.getElementById('enable2faBtn').textContent = 'Activer';
                     } else { alert(res.message || 'Erreur'); }
@@ -1945,258 +1542,6 @@
             });
         }
 
-        function initToolModal() {
-            const toolModal = document.getElementById('toolModal');
-            const addToolBtn = document.getElementById('addToolBtn');
-            const addToolBtnEmpty = document.getElementById('addToolBtnEmpty');
-            const closeToolModal = document.getElementById('closeToolModal');
-            const cancelToolModal = document.getElementById('cancelToolModal');
-            const submitToolForm = document.getElementById('submitToolForm');
-            const submitSpinner = document.getElementById('submitSpinner');
-            const submitText = document.getElementById('submitText');
-            const toolForm = document.getElementById('toolForm');
-            const toolModalTitle = document.getElementById('toolModalTitle');
-
-            if (!toolModal || !addToolBtn || !addToolBtnEmpty) {
-                return;
-            }
-            
-            addToolBtn.addEventListener('click', () => {
-                currentEditingToolId = null;
-                toolModalTitle.textContent = 'Publier un nouveau tool';
-                submitText.textContent = 'Publier';
-                toolForm.reset();
-                document.getElementById('toolModalError').classList.add('hidden');
-                document.getElementById('toolModalSuccess').classList.add('hidden');
-                toolModal.classList.add('active');
-            });
-            
-            addToolBtnEmpty.addEventListener('click', () => {
-                currentEditingToolId = null;
-                toolModalTitle.textContent = 'Publier un nouveau tool';
-                submitText.textContent = 'Publier';
-                toolForm.reset();
-                document.getElementById('toolModalError').classList.add('hidden');
-                document.getElementById('toolModalSuccess').classList.add('hidden');
-                toolModal.classList.add('active');
-            });
-            
-            closeToolModal.addEventListener('click', () => {
-                toolModal.classList.remove('active');
-            });
-            
-            cancelToolModal.addEventListener('click', () => {
-                toolModal.classList.remove('active');
-            });
-            
-            submitToolForm.addEventListener('click', () => {
-                const title = document.getElementById('toolTitle').value.trim();
-                const description = document.getElementById('toolDescription').value.trim();
-                const category = document.getElementById('toolCategory').value;
-                const url = document.getElementById('toolUrl').value.trim();
-                const tags = document.getElementById('toolTags').value.trim();
-                const imageFile = document.getElementById('toolImage').files[0];
-                
-                if (!title || !description || !category || !url) {
-                    showModalError('Veuillez remplir tous les champs obligatoires');
-                    return;
-                }
-                
-                submitSpinner.classList.remove('hidden');
-                submitText.textContent = 'Envoi en cours...';
-                submitToolForm.disabled = true;
-                closeToolModal.disabled = true;
-                cancelToolModal.disabled = true;
-                
-                const token = localStorage.getItem('token');
-                const formData = new FormData();
-                
-                formData.append('title', title);
-                formData.append('description', description);
-                formData.append('category', category);
-                formData.append('url', url);
-                if (tags) formData.append('tags', tags);
-                if (imageFile) formData.append('image', imageFile);
-                
-                let apiEndpoint = `${apiBaseURL}/tools/add`;
-                let method = 'POST';
-                
-                if (currentEditingToolId) {
-                    apiEndpoint = `${apiBaseURL}/tools/${currentEditingToolId}`;
-                    method = 'PUT';
-                }
-                
-                fetch(apiEndpoint, {
-                    method: method,
-                    headers: {
-                        'Authorization': `Bearer ${token}`
-                    },
-                    body: formData
-                })
-                .then(response => response.json())
-                .then(data => {
-                    if (data.success) {
-                        showModalSuccess(currentEditingToolId ? 
-                            'Tool mis à jour avec succès !' : 
-                            'Tool soumis avec succès ! Il sera publié après modération.');
-                        
-                        if (!currentEditingToolId) {
-                            toolForm.reset();
-                            document.getElementById('noTools').classList.add('hidden');
-                            document.getElementById('toolsGrid').classList.remove('hidden');
-                        }
-                        
-                        setTimeout(() => {
-                            fetchUserTools().then(() => {
-                                toolModal.classList.remove('active');
-                            });
-                        }, 1500);
-                    } else {
-                        if (typeof data.retry_after_seconds !== "undefined") {
-                            let seconds = parseInt(data.retry_after_seconds, 10);
-                            let hours = Math.floor(seconds / 3600);
-                            let minutes = Math.floor((seconds % 3600) / 60);
-                            let s = seconds % 60;
-                            let timeStr = [];
-                            if (hours > 0) timeStr.push(hours + "h");
-                            if (minutes > 0) timeStr.push(minutes + "min");
-                            if (s > 0 && hours === 0) timeStr.push(s + "s");
-                            showModalError(
-                                (data.message || "Vous devez attendre avant de soumettre un nouvel outil.") +
-                                "<br>Veuillez réessayer dans " + timeStr.join(" ") + "."
-                            );
-                        } else {
-                            throw new Error(data.message || 'Erreur lors de la soumission du tool');
-                        }
-                    }
-                })
-                .catch(error => {
-                    showModalError(error.message);
-                })
-                .finally(() => {
-                    submitSpinner.classList.add('hidden');
-                    submitText.textContent = currentEditingToolId ? 'Mettre à jour' : 'Publier';
-                    submitToolForm.disabled = false;
-                    closeToolModal.disabled = false;
-                    cancelToolModal.disabled = false;
-                });
-            });
-        }
-        
-        function openEditToolModal(toolId) {
-            const tool = currentUserTools.find(t => t.id === toolId || t.tool_id === toolId);
-            if (!tool) return;
-            
-            currentEditingToolId = toolId;
-            const toolModal = document.getElementById('toolModal');
-            const toolModalTitle = document.getElementById('toolModalTitle');
-            const submitText = document.getElementById('submitText');
-            
-            toolModalTitle.textContent = 'Modifier le tool';
-            submitText.textContent = 'Mettre à jour';
-            document.getElementById('toolModalError').classList.add('hidden');
-            document.getElementById('toolModalSuccess').classList.add('hidden');
-            
-            document.getElementById('toolTitle').value = tool.title;
-            document.getElementById('toolDescription').value = tool.description;
-            document.getElementById('toolCategory').value = tool.category || '';
-            document.getElementById('toolUrl').value = tool.content_url || tool.url;
-            document.getElementById('toolTags').value = tool.tags ? (Array.isArray(tool.tags) ? tool.tags.join(', ') : tool.tags) : '';
-            
-            toolModal.classList.add('active');
-        }
-        
-        function initDeleteModal() {
-            const deleteModal = document.getElementById('deleteModal');
-            const closeDeleteModal = document.getElementById('closeDeleteModal');
-            const cancelDeleteModal = document.getElementById('cancelDeleteModal');
-            const confirmDeleteModal = document.getElementById('confirmDeleteModal');
-            const deleteSpinner = document.getElementById('deleteSpinner');
-            const deleteText = document.getElementById('deleteText');
-
-            if (!deleteModal || !closeDeleteModal || !cancelDeleteModal || !confirmDeleteModal) {
-                return;
-            }
-            
-            closeDeleteModal.addEventListener('click', () => {
-                deleteModal.classList.remove('active');
-            });
-            
-            cancelDeleteModal.addEventListener('click', () => {
-                deleteModal.classList.remove('active');
-            });
-            
-            confirmDeleteModal.addEventListener('click', () => {
-                const toolId = currentEditingToolId;
-                if (!toolId) return;
-                
-                deleteSpinner.classList.remove('hidden');
-                deleteText.textContent = 'Suppression...';
-                confirmDeleteModal.disabled = true;
-                closeDeleteModal.disabled = true;
-                cancelDeleteModal.disabled = true;
-                
-                const token = localStorage.getItem('token');
-                
-                fetch(`${apiBaseURL}/tools/delete/${toolId}`, {
-                    method: 'DELETE',
-                    headers: {
-                        'Authorization': `Bearer ${token}`
-                    }
-                })
-                .then(response => response.json())
-                .then(data => {
-                    if (data.success) {
-                        showSuccess('Tool supprimé avec succès');
-                        deleteModal.classList.remove('active');
-                        
-                        fetchUserTools();
-                    } else {
-                        throw new Error(data.message || 'Erreur lors de la suppression du tool');
-                    }
-                })
-                .catch(error => {
-                    showError(error.message);
-                })
-                .finally(() => {
-                    deleteSpinner.classList.add('hidden');
-                    deleteText.textContent = 'Supprimer';
-                    confirmDeleteModal.disabled = false;
-                    closeDeleteModal.disabled = false;
-                    cancelDeleteModal.disabled = false;
-                });
-            });
-        }
-        
-        function openDeleteModal(toolId) {
-            currentEditingToolId = toolId;
-            const modal = document.getElementById('deleteModal');
-            if (modal) {
-                modal.classList.add('active');
-            }
-        }
-        
-        function showModalError(message) {
-            const errorContainer = document.getElementById('toolModalError');
-            errorContainer.innerHTML = `
-                <div class="error-message">
-                    <img src="/assets/error.png" alt="Erreur" class="error-icon">
-                    <span>${message}</span>
-                </div>
-            `;
-            errorContainer.classList.remove('hidden');
-        }
-        
-        function showModalSuccess(message) {
-            const successContainer = document.getElementById('toolModalSuccess');
-            successContainer.innerHTML = `
-                <div class="success-message">
-                    <img src="/assets/success.png" alt="Succès" class="success-icon">
-                    <span>${message}</span>
-                </div>
-            `;
-            successContainer.classList.remove('hidden');
-        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement session management backend
- return session ID on login
- expose session endpoints in router and README
- add new changelog entry
- add 2FA modal and simplify security page
- remove obsolete tool management code

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cdb6f04cc8320b9d81476b581cdd2