### PR TITLE
Handle 2FA login screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - 💬 **Like, comment and share** other people's tools
 - 👤 **Manage your account**: avatar, security, statistics
 - 🔐 **Two-factor authentication** with Google Authenticator
+- 🤖 Smooth 2FA prompt with captcha when signing in if your account requires it
 - 🔑 **Password reset** via email link
 - 🖥️ **Manage active sessions** in your security settings
 - 🛡️ A clean **moderation system**

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -245,5 +245,18 @@
     "tags": [
       ""
     ]
+  },
+  {
+    "id": 30,
+    "date": "2025-10-10",
+    "displayDate": "10/10/2025",
+    "title": "Nouvelle étape 2FA lors de la connexion",
+    "summary": "La transition vers la saisie du code d'authentification est maintenant animée, captcha conservé.",
+    "content": "Lorsqu'un compte protège la connexion par 2FA, la page affiche désormais automatiquement un écran dédié pour entrer le code après avoir validé l'email et le mot de passe tout en laissant le captcha visible.",
+    "isNew": true,
+    "isPrivate": true,
+    "tags": [
+      "frontend"
+    ]
   }
 ]

--- a/frontend/ressources/CSS/signin.css
+++ b/frontend/ressources/CSS/signin.css
@@ -2,6 +2,7 @@
     --primary-color: #2a00d9;
     --primary-hover: #3000FF;
     --error-color: #ff5a5a;
+    --success-color: #4BB543;
     --dark-bg: linear-gradient(135deg, #121212, #1a1a1a);
     --dark-card: #1e1e1e;
     --dark-input: #2a2a2a;
@@ -393,6 +394,40 @@
 
   .login-options a:hover::after {
     width: 100%;
+  }
+
+  .twofactor-state {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    animation: successContentIn 0.6s cubic-bezier(0.2, 0.8, 0.4, 1) both;
+    animation-delay: 0.4s;
+  }
+
+  #twofactor-state .input-group {
+    margin-top: 20px;
+  }
+
+  .success-icon {
+    width: 80px;
+    height: 80px;
+    margin-bottom: 25px;
+    animation: checkmark 0.6s cubic-bezier(0.2, 0.8, 0.4, 1.5) both;
+  }
+
+  .success-title {
+    font-size: 28px;
+    margin-bottom: 15px;
+    font-weight: 600;
+    color: var(--success-color);
+  }
+
+  .success-message {
+    font-size: 16px;
+    margin-bottom: 30px;
+    color: rgba(255, 255, 255, 0.8);
+    line-height: 1.6;
   }
 
   body.light-theme { 

--- a/frontend/ressources/JS/signin.js
+++ b/frontend/ressources/JS/signin.js
@@ -20,6 +20,7 @@ themeSwitcher.addEventListener('click', () => {
   localStorage.setItem('theme', isLight ? 'light' : 'dark');
   updateSwitcherIcon();
 });
+const CAPTCHA_SITEKEY = '0x4AAAAAABgYeaoGcgRuhRX3';
 let apiBaseURL = "";
 fetch('/ressources/utils/api').then(res => res.text()).then(url => { apiBaseURL = url; });
 const loginButton = document.getElementById('login-button');
@@ -27,9 +28,18 @@ const emailInput = document.querySelector('input[name="email"]');
 const passwordInput = document.querySelector('input[name="password"]');
 const twoFactorGroup = document.getElementById('twofactor-group');
 const twoFactorInput = document.querySelector('input[name="two_factor_code"]');
+const twoFactorState = document.getElementById('twofactor-state');
+const twoFactorCode = document.getElementById('twofactor-code');
+const twoFactorButton = document.getElementById('twofactor-button');
 const formError = document.getElementById('form-error');
 const errorText = document.getElementById('error-text');
 const loginForm = document.getElementById('login-form');
+const loginTurnstile = document.getElementById('signin-turnstile');
+const twofactorTurnstile = document.getElementById('twofactor-turnstile');
+if(loginTurnstile){ loginTurnstile.setAttribute('data-sitekey', CAPTCHA_SITEKEY); }
+if(twofactorTurnstile){ twofactorTurnstile.setAttribute('data-sitekey', CAPTCHA_SITEKEY); }
+let storedEmail = '';
+let storedPassword = '';
 let captchaToken = '';
 window.onCaptchaSuccess = function(token){ captchaToken = token; };
 const CAPTCHA_MISSING_MSG = 'Veuillez compléter le captcha';
@@ -63,6 +73,13 @@ if(twoFactorInput){
     formError.classList.remove('show');
   });
 }
+if(twoFactorCode){
+  twoFactorCode.addEventListener('input', () => {
+    twoFactorButton.disabled = twoFactorCode.value.trim().length !== 6;
+    twoFactorCode.classList.remove('input-error');
+    formError.classList.remove('show');
+  });
+}
 function showError(message) {
   errorText.textContent = message;
   formError.classList.add('show');
@@ -71,13 +88,32 @@ function showError(message) {
   } else if (message.toLowerCase().includes('mot de passe')) {
     passwordInput.classList.add('input-error');
   } else if (message.toLowerCase().includes('2fa')) {
-    if(twoFactorGroup.style.display==='none'){ twoFactorGroup.style.display='block'; }
-    twoFactorInput.classList.add('input-error');
+    if(twoFactorState.style.display === 'flex'){
+      twoFactorCode.classList.add('input-error');
+    } else {
+      if(twoFactorGroup.style.display==='none'){ twoFactorGroup.style.display='block'; }
+      twoFactorInput.classList.add('input-error');
+    }
   } else {
     emailInput.classList.add('input-error');
     passwordInput.classList.add('input-error');
   }
   formError.scrollIntoView({ behavior: 'smooth', block: 'center' });
+}
+
+function showTwoFactorState() {
+  const elements = Array.from(document.querySelectorAll('.login-form, .login-options, .login-title'));
+  elements.forEach(el => {
+    el.style.animation = 'fadeOut 0.4s ease forwards';
+  });
+  setTimeout(() => {
+    elements.forEach(el => {
+      el.style.display = 'none';
+    });
+    twoFactorState.style.display = 'flex';
+    twoFactorButton.disabled = twoFactorCode.value.trim().length !== 6;
+    twoFactorCode.focus();
+  }, 400);
 }
 loginForm.addEventListener('submit', async function(e) {
   e.preventDefault();
@@ -117,11 +153,14 @@ loginForm.addEventListener('submit', async function(e) {
       setTimeout(() => {
         window.location.href = '/account/';
       }, 1000);
+    } else if (data.two_factor_required) {
+      storedEmail = emailInput.value.trim();
+      storedPassword = passwordInput.value.trim();
+      showTwoFactorState();
+      loginButton.disabled = false;
+      loginButton.innerHTML = '<span>Connexion</span>';
     } else {
       showError(data.message || "Email ou mot de passe incorrect");
-      if(data.two_factor_required){
-        twoFactorGroup.style.display = 'block';
-      }
       loginButton.disabled = false;
       loginButton.innerHTML = '<span>Connexion</span>';
     }
@@ -135,3 +174,50 @@ loginForm.addEventListener('submit', async function(e) {
     captchaToken = '';
   }
 });
+
+if(twoFactorButton){
+  twoFactorButton.addEventListener('click', async () => {
+    if(twoFactorCode.value.trim().length !== 6){
+      showError('Veuillez entrer le code 2FA');
+      return;
+    }
+    if(!captchaToken){
+      showError(CAPTCHA_MISSING_MSG);
+      return;
+    }
+    twoFactorButton.disabled = true;
+    twoFactorButton.innerHTML = '<span>Vérification...</span>';
+    try {
+      const response = await fetch(`${apiBaseURL}/auth/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          email: storedEmail,
+          password: storedPassword,
+          turnstile_token: captchaToken,
+          two_factor_code: twoFactorCode.value.trim()
+        })
+      });
+      const data = await response.json();
+      if(response.ok){
+        if (data.token) {
+          localStorage.setItem('token', data.token);
+        }
+        twoFactorButton.innerHTML = '<span>Connexion réussie!</span>';
+        setTimeout(() => { window.location.href = '/account/'; }, 1000);
+      } else {
+        showError(data.message || 'Code 2FA invalide');
+        twoFactorButton.disabled = false;
+        twoFactorButton.innerHTML = '<span>Valider</span>';
+      }
+    } catch(err){
+      showError('Erreur de connexion au serveur');
+      twoFactorButton.disabled = false;
+      twoFactorButton.innerHTML = '<span>Valider</span>';
+    }
+    turnstile.reset('#twofactor-turnstile');
+    captchaToken = '';
+  });
+}

--- a/frontend/signin.html
+++ b/frontend/signin.html
@@ -54,6 +54,24 @@
         <p><a href="/forgot">Mot de passe oublié ?</a></p>
         <p>Pas de compte ? <a href="/signup">Inscription</a></p>
       </div>
+
+        <div class="twofactor-state" id="twofactor-state" style="display:none;">
+          <img src="/assets/code.png" alt="2FA" class="success-icon">
+          <h3 class="success-title">Code d'authentification requis</h3>
+          <p class="success-message">
+            Saisissez le code généré par votre application d'authentification pour poursuivre.
+          </p>
+          <div class="input-group">
+            <img src="/assets/code.png" alt="2FA Icon" class="input-icon">
+            <input type="text" id="twofactor-code" placeholder="Code 2FA" maxlength="6">
+          </div>
+          <div class="captcha-wrapper">
+            <div id="twofactor-turnstile" class="cf-turnstile" data-sitekey="0x4AAAAAABgYeaoGcgRuhRX3" data-callback="onCaptchaSuccess"></div>
+          </div>
+          <button type="button" class="login-button" id="twofactor-button" disabled>
+            <span>Valider</span>
+          </button>
+        </div>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- show captcha in the dedicated 2FA state
- add captcha sitekey constant and update JS to handle captcha checks
- keep the captcha visible when the code entry screen is displayed
- document the improved workflow in README and private news

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685dec79dbac83208b57889e6e040967