### PR TITLE
Add API outage banner with automatic error rate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A new `private_news_password` field secures access to private news articles.
 Set `cors_allowed_origin` to control the `Access-Control-Allow-Origin` header.
 Use the `storage` section to configure directories for avatars and tool images.
 The `moderation` section now includes `auto_unban` to automatically lift temporary bans when expired.
+The `status_banner` section controls the outage banner displayed on the frontend.
 
 ### Useful API endpoints
 - `POST /v{n}/admin/logs/clear` – clear all activity logs
@@ -68,6 +69,7 @@ The `moderation` section now includes `auto_unban` to automatically lift tempora
 - `GET /v{n}/auth/sessions` – list active sessions
 - `DELETE /v{n}/auth/sessions` – revoke all other sessions
 - `DELETE /v{n}/auth/sessions/{id}` – revoke a specific session
+- `GET /v{n}/status` – check API health status
 
 ---
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -65,9 +65,15 @@ type Config struct {
         TwoFactor struct {
                 Issuer string `json:"issuer"`
         } `json:"two_factor"`
-       PasswordReset struct {
-               TokenExpiryMinutes int `json:"token_expiry_minutes"`
-       } `json:"password_reset"`
+        PasswordReset struct {
+                TokenExpiryMinutes int `json:"token_expiry_minutes"`
+        } `json:"password_reset"`
+       StatusBanner struct {
+               ErrorRateThreshold float64 `json:"error_rate_threshold"`
+               WindowMinutes      int     `json:"window_minutes"`
+               Link               string  `json:"link"`
+               Message            string  `json:"message"`
+       } `json:"status_banner"`
         PrivateNewsPassword string `json:"private_news_password"`
 }
 
@@ -91,6 +97,15 @@ func Load(path string) error {
        }
        if cfg.PasswordReset.TokenExpiryMinutes == 0 {
                cfg.PasswordReset.TokenExpiryMinutes = 15
+       }
+       if cfg.StatusBanner.WindowMinutes == 0 {
+               cfg.StatusBanner.WindowMinutes = 10
+       }
+       if cfg.StatusBanner.ErrorRateThreshold == 0 {
+               cfg.StatusBanner.ErrorRateThreshold = 0.3
+       }
+       if cfg.StatusBanner.Message == "" {
+               cfg.StatusBanner.Message = "Des perturbations sont en cours."
        }
        mu.Lock()
        Current = cfg

--- a/api/example config.json
+++ b/api/example config.json
@@ -55,5 +55,11 @@
   "password_reset": {
     "token_expiry_minutes": 15
   },
+  "status_banner": {
+    "error_rate_threshold": 0.3,
+    "window_minutes": 10,
+    "link": "",
+    "message": "Des perturbations sont en cours."
+  },
   "private_news_password": "change-me"
 }

--- a/api/main.go
+++ b/api/main.go
@@ -113,11 +113,12 @@ func setupRoutes(r *gin.Engine) {
 
 	api := r.Group("/" + cfg.URLVersion)
 
-	api.GET("/", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"message": fmt.Sprintf("ToolCenter API v%s is running", cfg.Version),
-		})
-	})
+        api.GET("/", func(c *gin.Context) {
+                c.JSON(200, gin.H{
+                        "message": fmt.Sprintf("ToolCenter API v%s is running", cfg.Version),
+                })
+        })
+       api.GET("/status", utils.StatusHandler)
 
 	authGroup := api.Group("/auth")
 	authGroup.POST("/login", auth.LoginHandler)
@@ -186,9 +187,10 @@ func main() {
 		gin.SetMode(cfg.GinMode)
 	}
 
-	r := gin.Default()
-	r.Use(corsMiddleware())
-	setupRoutes(r)
+       r := gin.Default()
+       r.Use(corsMiddleware())
+       r.Use(utils.MonitorMiddleware())
+       setupRoutes(r)
 
 	log.Printf("✅ API ToolCenter démarrée sur le port %d", cfg.Port)
 	r.Run(fmt.Sprintf(":%d", cfg.Port))

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -285,5 +285,19 @@
       "frontend",
       "backend"
     ]
+  },
+  {
+    "id": 33,
+    "date": "2025-10-30",
+    "displayDate": "30/10/2025",
+    "title": "Bandeau d'alerte automatique",
+    "summary": "Un bandeau informe des problèmes serveur selon le taux d'erreur.",
+    "content": "Un nouveau script vérifie l'API et affiche un bandeau en haut du site lorsque le taux d'erreur dépasse un seuil défini dans la configuration.",
+    "isNew": true,
+    "isPrivate": true,
+    "tags": [
+      "frontend",
+      "backend"
+    ]
   }
 ]

--- a/api/utils/status_banner.go
+++ b/api/utils/status_banner.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+    "sync"
+    "time"
+
+    "toolcenter/config"
+
+    "github.com/gin-gonic/gin"
+    "net/http"
+    "fmt"
+)
+
+var (
+    mu        sync.Mutex
+    reqTimes  []time.Time
+    errTimes  []time.Time
+)
+
+func recordRequest(isError bool) {
+    mu.Lock()
+    defer mu.Unlock()
+    now := time.Now()
+    reqTimes = append(reqTimes, now)
+    if isError {
+        errTimes = append(errTimes, now)
+    }
+    cleanup()
+}
+
+func cleanup() {
+    cfg := config.Get()
+    window := cfg.StatusBanner.WindowMinutes
+    if window == 0 {
+        window = 10
+    }
+    cutoff := time.Now().Add(-time.Duration(window) * time.Minute)
+    for len(reqTimes) > 0 && reqTimes[0].Before(cutoff) {
+        reqTimes = reqTimes[1:]
+    }
+    for len(errTimes) > 0 && errTimes[0].Before(cutoff) {
+        errTimes = errTimes[1:]
+    }
+}
+
+type Status struct {
+    ErrorRate    float64 `json:"error_rate"`
+    RequestCount int     `json:"request_count"`
+    ErrorCount   int     `json:"error_count"`
+}
+
+// MonitorMiddleware records every request and whether it ended in an error.
+func MonitorMiddleware() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        c.Next()
+        recordRequest(c.Writer.Status() >= 500)
+    }
+}
+
+func getStatus() Status {
+    mu.Lock()
+    defer mu.Unlock()
+    cleanup()
+    total := len(reqTimes)
+    errors := len(errTimes)
+    rate := 0.0
+    if total > 0 {
+        rate = float64(errors) / float64(total)
+    }
+    return Status{
+        ErrorRate:    rate,
+        RequestCount: total,
+        ErrorCount:   errors,
+    }
+}
+
+// StatusHandler exposes current error rate information.
+func StatusHandler(c *gin.Context) {
+    st := getStatus()
+    cfg := config.Get()
+    show := st.ErrorRate >= cfg.StatusBanner.ErrorRateThreshold && st.RequestCount > 0
+    if show {
+        msg := fmt.Sprintf("%s (%.0f%% d'erreurs)", cfg.StatusBanner.Message, st.ErrorRate*100)
+        c.JSON(http.StatusOK, gin.H{
+            "show_banner": true,
+            "message":     msg,
+            "link":        cfg.StatusBanner.Link,
+        })
+        return
+    }
+    c.JSON(http.StatusOK, gin.H{"show_banner": false})
+}
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/ressources/CSS/index.css">
   <script src="/ressources/JS/main.js" defer></script>
   <script src="/ressources/utils/anti-scam.js" defer></script>
+  <script src="/ressources/JS/api-status-banner.js" defer></script>
 </head>
 <body>
   <div id="preloader">

--- a/frontend/ressources/JS/api-status-banner.js
+++ b/frontend/ressources/JS/api-status-banner.js
@@ -1,0 +1,46 @@
+async function checkApiStatus() {
+  try {
+    const baseUrlResponse = await fetch('/ressources/utils/api');
+    const baseUrl = (await baseUrlResponse.text()).trim();
+    const res = await fetch(baseUrl + '/status');
+    const data = await res.json();
+    if (data.show_banner) {
+      showStatusBanner(data.message, data.link);
+    }
+  } catch (err) {
+    console.log('[TC LOGS] Failed to fetch API status:', err);
+  }
+}
+
+function showStatusBanner(message, link) {
+  let banner = document.getElementById('tc-status-banner');
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'tc-status-banner';
+    banner.style.position = 'fixed';
+    banner.style.top = '0';
+    banner.style.left = '0';
+    banner.style.right = '0';
+    banner.style.zIndex = '1000';
+    banner.style.background = '#e63946';
+    banner.style.color = '#fff';
+    banner.style.padding = '10px';
+    banner.style.textAlign = 'center';
+    banner.style.fontWeight = '600';
+    document.body.prepend(banner);
+  } else {
+    banner.innerHTML = '';
+  }
+  banner.textContent = message;
+  if (link) {
+    const a = document.createElement('a');
+    a.href = link;
+    a.textContent = 'En savoir plus';
+    a.style.color = '#fff';
+    a.style.marginLeft = '10px';
+    a.style.textDecoration = 'underline';
+    banner.appendChild(a);
+  }
+}
+
+window.addEventListener('load', checkApiStatus);


### PR DESCRIPTION
## Summary
- monitor errors and expose `/status` endpoint
- display outage banner via new frontend script
- document the new configuration and endpoint
- update private articles with a note about the banner

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860c0b54f1483208ea3f8621cacc970