### PR TITLE
Improve activity logs with page info

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -330,4 +330,6 @@ Le worker Go embarqué tourne en continu et **supprime** les comptes **non véri
 
 * Pense à importer le **schema SQL** (`db/schema.sql`) avant premier lancement.
 * Active les logs pour savoir quand ça casse (fichier `logs/api.log`).
+* Même les actions réussies enregistrent désormais un message explicite dans les logs.
+* Les logs indiquent la page d'origine pour chaque appel API (`<page> | message`).
 * Contributions bienvenues : *fork → feat branch → PR* 🚀

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -41,8 +41,9 @@ type Config struct {
 	DiscordWebhookURL string `json:"discord_webhook_url"`
 	WebhookSecret     string `json:"webhook_secret"`
 	Turnstile         struct {
-		SignInSecret string `json:"signin_secret"`
-		SignUpSecret string `json:"signup_secret"`
+		SignInSecret   string `json:"signin_secret"`
+		SignUpSecret   string `json:"signup_secret"`
+		TimeoutSeconds int    `json:"timeout_seconds"`
 	} `json:"turnstile"`
 	Cleanup struct {
 		CheckInterval int `json:"check_interval"`
@@ -75,7 +76,10 @@ type Config struct {
 		Message             string  `json:"message"`
 		ActivatedForTesting bool    `json:"activated_for_testing"`
 	} `json:"status_banner"`
-	PrivateNewsPassword string `json:"private_news_password"`
+	PrivateNews struct {
+		Password   string `json:"password"`
+		TokenHours int    `json:"token_hours"`
+	} `json:"private_news"`
 }
 
 func Load(path string) error {
@@ -107,6 +111,12 @@ func Load(path string) error {
 	}
 	if cfg.StatusBanner.Message == "" {
 		cfg.StatusBanner.Message = "Des perturbations sont en cours."
+	}
+	if cfg.Turnstile.TimeoutSeconds == 0 {
+		cfg.Turnstile.TimeoutSeconds = 5
+	}
+	if cfg.PrivateNews.TokenHours == 0 {
+		cfg.PrivateNews.TokenHours = 24
 	}
 	mu.Lock()
 	Current = cfg

--- a/api/example config.json
+++ b/api/example config.json
@@ -29,7 +29,8 @@
   "webhook_secret": "",
   "turnstile": {
     "signin_secret": "YOUR_SIGNIN_SECRET_KEY",
-    "signup_secret": "YOUR_SIGNUP_SECRET_KEY"
+    "signup_secret": "YOUR_SIGNUP_SECRET_KEY",
+    "timeout_seconds": 5
   },
   "cleanup": {
     "check_interval": 600,
@@ -62,5 +63,8 @@
     "message": "Des perturbations sont en cours.",
     "activated_for_testing": true
   },
-  "private_news_password": "change-me"
+  "private_news": {
+    "password": "change-me",
+    "token_hours": 24
+  }
 }

--- a/api/utils/activity_log.go
+++ b/api/utils/activity_log.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"database/sql"
+	"log"
 
 	"toolcenter/config"
 
@@ -13,12 +14,17 @@ import (
 func LogActivity(c *gin.Context, userID, action string, success bool, message string) {
 	db, err := config.OpenDB()
 	if err != nil {
+		log.Println("logactivity: open db:", err)
 		return
 	}
 	defer db.Close()
 
 	ip := c.ClientIP()
 	ua := c.Request.UserAgent()
+	page := c.Request.Referer()
+	if page == "" {
+		page = c.FullPath()
+	}
 
 	var uid interface{}
 	if userID == "" {
@@ -27,6 +33,13 @@ func LogActivity(c *gin.Context, userID, action string, success bool, message st
 		uid = userID
 	}
 
-	_, _ = db.Exec(`INSERT INTO activity_logs (user_id, ip_address, user_agent, action, success, message) VALUES (?, ?, ?, ?, ?, ?)`,
-		uid, ip, ua, action, success, message)
+	if success && message == "" {
+		message = "success"
+	}
+	message = page + " | " + message
+
+	if _, err := db.Exec(`INSERT INTO activity_logs (user_id, ip_address, user_agent, action, success, message) VALUES (?, ?, ?, ?, ?, ?)`,
+		uid, ip, ua, action, success, message); err != nil {
+		log.Println("logactivity: insert:", err)
+	}
 }

--- a/api/utils/privates_news.go
+++ b/api/utils/privates_news.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -14,8 +15,11 @@ import (
 	"toolcenter/config"
 )
 
-var lastToken string
-var lastTokenExpiration time.Time
+var (
+	lastToken           string
+	lastTokenExpiration time.Time
+	tokenMu             sync.RWMutex
+)
 
 // Pour ajouter des tags à un article, il suffit d'ajouter les chaînes désirées dans le tableau.
 // Exemple : []string{"pinned", "urgent", "important", "todo", "inprogress", "done", "obsolete"},
@@ -64,9 +68,11 @@ func PrivateNewsHandler(c *gin.Context) {
 	}
 
 	if req.Password != "" {
-		if req.Password == config.Get().PrivateNewsPassword {
+		if req.Password == config.Get().PrivateNews.Password {
+			tokenMu.Lock()
 			lastToken = generateToken(32)
-			lastTokenExpiration = time.Now().Add(24 * time.Hour)
+			lastTokenExpiration = time.Now().Add(time.Duration(config.Get().PrivateNews.TokenHours) * time.Hour)
+			tokenMu.Unlock()
 			c.JSON(http.StatusOK, gin.H{
 				"success":  true,
 				"token":    lastToken,
@@ -79,7 +85,10 @@ func PrivateNewsHandler(c *gin.Context) {
 	}
 
 	if req.Token != "" {
-		if req.Token == lastToken && time.Now().Before(lastTokenExpiration) {
+		tokenMu.RLock()
+		valid := req.Token == lastToken && time.Now().Before(lastTokenExpiration)
+		tokenMu.RUnlock()
+		if valid {
 			c.JSON(http.StatusOK, gin.H{
 				"success":  true,
 				"articles": articles,

--- a/api/utils/turnstile.go
+++ b/api/utils/turnstile.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"time"
+
+	"toolcenter/config"
 )
 
 func VerifyTurnstile(token, secret, remoteIP string) (bool, error) {
@@ -13,7 +16,12 @@ func VerifyTurnstile(token, secret, remoteIP string) (bool, error) {
 	if remoteIP != "" {
 		data.Set("remoteip", remoteIP)
 	}
-	resp, err := http.PostForm("https://challenges.cloudflare.com/turnstile/v0/siteverify", data)
+	timeout := time.Duration(config.Get().Turnstile.TimeoutSeconds) * time.Second
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.PostForm("https://challenges.cloudflare.com/turnstile/v0/siteverify", data)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Summary
- include Turnstile timeout and private news token settings in config
- prefix activity log messages with the originating page
- lock private news token generation and make expiry configurable
- allow Turnstile HTTP timeout to be configured
- document page info in logs

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6860cd28878483208759ae3ae068a4d8