### PR TITLE
Add Vite build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ storage/tools_images/*
 /api/toolcenter
 /api/config.json
 /api/logs/api.log
+frontend/dist
+frontend/node_modules
+

--- a/README.md
+++ b/README.md
@@ -62,7 +62,20 @@ Use the `storage` section to configure directories for avatars and tool images.
 The `moderation` section now includes `auto_unban` to automatically lift temporary bans when expired.
 The `status_banner` section controls the outage banner displayed on the frontend.
 `user_public_tools_limit` defines how many public tools are returned in user search results.
-Update `frontend/src/utils/config.js` to change the API base URL used by the static pages.
+Update `frontend/src/utils/config.js` to change the API base URL used by the static pages or set `VITE_API_BASE_URL` in a `.env` file for Vite.
+
+### Build the frontend with Vite
+
+The `frontend` directory now includes a Vite configuration. To build the optimized assets:
+
+```bash
+cd frontend
+npm install
+cp .env.example .env  # adjust VITE_API_BASE_URL if necessary
+npm run build
+```
+
+This will generate a `dist` folder containing the static site ready to deploy.
 
 ### Useful API endpoints
 - `POST /v{n}/admin/logs/clear` – clear all activity logs

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -312,5 +312,18 @@
     "tags": [
       "backend"
     ]
+  },
+  {
+    "id": 35,
+    "date": "2025-11-01",
+    "displayDate": "01/11/2025",
+    "title": "Intégration de Vite pour le frontend",
+    "summary": "Le frontend peut désormais être buildé via Vite.",
+    "content": "Une configuration Vite permet de compiler les fichiers HTML, JS et CSS du site. Installez Vite via npm puis lancez `npm run build` pour générer le dossier `dist`.",
+    "isNew": true,
+    "isPrivate": true,
+    "tags": [
+      "frontend"
+    ]
   }
 ]

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://api.tool-center.fr/v2

--- a/frontend/403.html
+++ b/frontend/403.html
@@ -53,7 +53,7 @@
         </footer>
     </div>
 
-    <script src="/src/utils/config.js"></script>
+    <script type="module" src="/src/utils/config.js"></script>
     <script type="module" src="/src/JS/404-403.js"></script>
 </body>
 </html>

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -53,7 +53,7 @@
         </footer>
     </div>
 
-    <script src="/src/utils/config.js"></script>
+    <script type="module" src="/src/utils/config.js"></script>
     <script type="module" src="/src/JS/404-403.js"></script>
 </body>
 </html>

--- a/frontend/account/index.html
+++ b/frontend/account/index.html
@@ -260,7 +260,7 @@
         </div>
     </div>
 
-    <script src="/src/utils/config.js"></script>
+    <script type="module" src="/src/utils/config.js"></script>
     <script type="module" src="/src/JS/account/index.js"></script>
 </body>
 </html>

--- a/frontend/account/logout.html
+++ b/frontend/account/logout.html
@@ -92,7 +92,7 @@
         </div>
     </div>
 
-    <script src="/src/utils/config.js"></script>
+    <script type="module" src="/src/utils/config.js"></script>
     <script type="module" src="/src/JS/account/logout.js"></script>
 </body>
 </html>

--- a/frontend/account/security.html
+++ b/frontend/account/security.html
@@ -264,7 +264,7 @@
         </div>
     </div>
     
-    <script src="/src/utils/config.js"></script>
+    <script type="module" src="/src/utils/config.js"></script>
     <script type="module" src="/src/JS/account/security.js"></script>
 </body>
 </html>

--- a/frontend/account/tools.html
+++ b/frontend/account/tools.html
@@ -294,7 +294,7 @@
         </div>
     </div>
     
-    <script src="/src/utils/config.js"></script>
+    <script type="module" src="/src/utils/config.js"></script>
     <script type="module" src="/src/JS/account/tools.js"></script>
 </body>
 </html>

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -1361,8 +1361,8 @@
 <div class="toast-container" id="toast-container">
 </div>
 
-  <script src="/src/utils/panel-config.js"></script>
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/panel-config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script>
     const BASE_API_URL = PANEL_CONFIG.API_BASE;
     const SECTION_IDS = { users: 'users-section', logs: 'logs-section' };

--- a/frontend/forgot.html
+++ b/frontend/forgot.html
@@ -10,7 +10,7 @@
   <link rel="preload" href="/assets/error.png" as="image">
   <link rel="stylesheet" href="/src/CSS/signin.css">
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script type="module" src="/src/JS/forgot.js"></script>
   <script src="/src/utils/anti-scam.js" defer></script>
 </head>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -147,7 +147,7 @@
     </p>
   </footer>
   
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script type="module" src="/src/JS/main.js"></script>
   <script src="/src/utils/anti-scam.js" defer></script>
   <script type="module" src="/src/JS/api-status-banner.js"></script>

--- a/frontend/legals.html
+++ b/frontend/legals.html
@@ -114,7 +114,7 @@
     .light-theme .toggle-btn { background: #eee; color: #444; }
     .light-theme .toggle-btn.active, .light-theme .toggle-btn:hover { background: #2a00d9; color: #fff; }
   </style>
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script type="module" src="/src/JS/main.js"></script>
 </head>
 <body>

--- a/frontend/news.html
+++ b/frontend/news.html
@@ -1548,7 +1548,7 @@
     </div>
   </div>
   
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script>
     let API_BASE_URL = window.API_BASE_URL;
     const PRIVATE_NEWS_ENDPOINT = '/utils/privates_news';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tool-center-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/prototypes/index2.html
+++ b/frontend/prototypes/index2.html
@@ -876,7 +876,7 @@
     </svg>
   </button>
 
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script>
     const menuIcon = document.getElementById('menu-icon');
     const sideMenu = document.getElementById('side-menu');

--- a/frontend/reset.html
+++ b/frontend/reset.html
@@ -9,7 +9,7 @@
   <link rel="preload" href="/assets/switcher-noir.png" as="image">
   <link rel="preload" href="/assets/error.png" as="image">
   <link rel="stylesheet" href="/src/CSS/signin.css">
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script type="module" src="/src/JS/reset.js"></script>
   <script src="/src/utils/anti-scam.js" defer></script>
 </head>

--- a/frontend/signin.html
+++ b/frontend/signin.html
@@ -10,7 +10,7 @@
   <link rel="preload" href="/assets/error.png" as="image">
   <link rel="stylesheet" href="/src/CSS/signin.css">
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script type="module" src="/src/JS/signin.js"></script>
   <script src="/src/utils/anti-scam.js" defer></script>
 </head>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -10,7 +10,7 @@
   <link rel="preload" href="/assets/error.png" as="image">
   <link rel="stylesheet" href="/src/CSS/signup.css">
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script type="module" src="/src/JS/signup.js"></script>
   <script src="/src/utils/anti-scam.js" defer></script>
 </head>

--- a/frontend/src/utils/config.js
+++ b/frontend/src/utils/config.js
@@ -1,1 +1,2 @@
-window.API_BASE_URL = 'https://api.tool-center.fr/v2';
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'https://api.tool-center.fr/v2';
+window.API_BASE_URL = API_BASE;

--- a/frontend/src/utils/panel-config.js
+++ b/frontend/src/utils/panel-config.js
@@ -1,7 +1,8 @@
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'https://api.tool-center.fr/v2';
 const PANEL_CONFIG = {
-  API_BASE: 'https://api.tool-center.fr/v2',
-  ADMIN_BASE: 'https://api.tool-center.fr/v2/admin',
-  MODERATION_BASE: 'https://api.tool-center.fr/v2/moderation',
+  API_BASE,
+  ADMIN_BASE: API_BASE + '/admin',
+  MODERATION_BASE: API_BASE + '/moderation',
   COLORS: {
     primary: '#6366f1',
     success: '#10b981',
@@ -14,3 +15,4 @@ const PANEL_CONFIG = {
 for (const [name, value] of Object.entries(PANEL_CONFIG.COLORS)) {
   document.documentElement.style.setProperty(`--${name}-color`, value);
 }
+window.PANEL_CONFIG = PANEL_CONFIG;

--- a/frontend/tools.html
+++ b/frontend/tools.html
@@ -16,7 +16,7 @@
   <link rel="preload" href="/assets/croix.png" as="image">
   <link rel="preload" href="/assets/switcher-noir.png" as="image">
   <link rel="stylesheet" href="/src/CSS/tools.css">
-  <script src="/src/utils/config.js"></script>
+  <script type="module" src="/src/utils/config.js"></script>
   <script type="module" src="/src/JS/tools.js"></script>
   <script src="/src/utils/anti-scam.js" defer></script>
 </head>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: __dirname,
+  base: './',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vite inside `frontend`
- expose API url through `VITE_API_BASE_URL`
- document Vite usage in README
- log Vite integration in private articles

## Testing
- `npm install --no-audit --no-fund`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ba34ad1d88320bf099f6cfae02b5e