### PR TITLE
Add anti-spam sanctions and user sanctions page

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The `moderation` section now includes `auto_unban` to automatically lift tempora
 The `status_banner` section controls the outage banner displayed on the frontend.
 `user_public_tools_limit` defines how many public tools are returned in user search results.
 `rate_limit` sets the maximum number of requests per IP and the time window in seconds.
+`spam_protection` fine-tunes the automatic blocking of spammers and the account status drop applied when abuse is detected.
 Update `frontend/src/utils/config.js` to change the API base URL used by the static pages or set `VITE_API_BASE_URL` in a `.env` file for Vite.
 
 ### Build the frontend with Vite

--- a/api/CONFIG DB ACTUELLE V6.sql
+++ b/api/CONFIG DB ACTUELLE V6.sql
@@ -189,12 +189,23 @@ CREATE TABLE moderation_actions (
   action_id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   moderator_id CHAR(36),
   user_id CHAR(36) NOT NULL,
-  action_type ENUM('Warn','Ban','Unban','Limit_Comments','Limit_Tools'),
+  action_type ENUM('Warn','Ban','Unban','Limit_Comments','Limit_Tools','Limit_API'),
   reason TEXT,
   start_date TIMESTAMP,
   end_date TIMESTAMP,
   action_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (moderator_id) REFERENCES users (user_id) ON DELETE SET NULL,
+  FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE user_sanctions (
+  sanction_id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  user_id CHAR(36) NOT NULL,
+  type VARCHAR(50),
+  reason TEXT,
+  start_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  end_date DATETIME,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 

--- a/api/README.md
+++ b/api/README.md
@@ -104,6 +104,7 @@ Réponse :
 | `POST`   | `/api/user/update_password` | Changer le mot de passe |
 | `POST`   | `/api/user/avatar`          | Mettre à jour l'avatar |
 | `DELETE` | `/api/user/delete`          | Supprimer le compte |
+| `GET`    | `/api/user/sanctions`       | Liste des sanctions |
 
 ### Utilisateur ↦ `/api/user/me`
 
@@ -172,6 +173,15 @@ Réponse :
 | `POST`   | `/api/tools`      | Publier un outil |
 | `GET`    | `/api/tools`      | Liste des outils |
 | `DELETE` | `/api/tools/:id`  | Supprimer un outil |
+
+### Voir ses sanctions ↦ `/api/user/sanctions`
+
+```bash
+curl -X GET https://api.tool-center.fr/api/user/sanctions \
+    -H "Authorization: Bearer <token>"
+```
+
+Renvoie un tableau de sanctions avec les dates de début et de fin.
 
 ### Modifier son pseudo ↦ `/api/user/update_username`
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -69,10 +69,17 @@ type Config struct {
 	PasswordReset struct {
 		TokenExpiryMinutes int `json:"token_expiry_minutes"`
 	} `json:"password_reset"`
-	RateLimit struct {
-		Requests      int `json:"requests"`
-		WindowSeconds int `json:"window_seconds"`
-	} `json:"rate_limit"`
+        RateLimit struct {
+                Requests      int `json:"requests"`
+                WindowSeconds int `json:"window_seconds"`
+        } `json:"rate_limit"`
+        SpamProtection struct {
+                BlockInitialSeconds int     `json:"block_initial_seconds"`
+                BlockMultiplier     float64 `json:"block_multiplier"`
+                SanctionThreshold   int     `json:"sanction_threshold"`
+                StatusDrop          int     `json:"status_drop"`
+                BanDays             int     `json:"ban_days"`
+        } `json:"spam_protection"`
 	StatusBanner struct {
 		ErrorRateThreshold  float64 `json:"error_rate_threshold"`
 		WindowMinutes       int     `json:"window_minutes"`
@@ -112,9 +119,24 @@ func Load(path string) error {
 	if cfg.RateLimit.Requests == 0 {
 		cfg.RateLimit.Requests = 60
 	}
-	if cfg.RateLimit.WindowSeconds == 0 {
-		cfg.RateLimit.WindowSeconds = 60
-	}
+        if cfg.RateLimit.WindowSeconds == 0 {
+                cfg.RateLimit.WindowSeconds = 60
+        }
+        if cfg.SpamProtection.BlockInitialSeconds == 0 {
+                cfg.SpamProtection.BlockInitialSeconds = 60
+        }
+        if cfg.SpamProtection.BlockMultiplier == 0 {
+                cfg.SpamProtection.BlockMultiplier = 2
+        }
+        if cfg.SpamProtection.SanctionThreshold == 0 {
+                cfg.SpamProtection.SanctionThreshold = 3
+        }
+        if cfg.SpamProtection.StatusDrop == 0 {
+                cfg.SpamProtection.StatusDrop = 2
+        }
+        if cfg.SpamProtection.BanDays == 0 {
+                cfg.SpamProtection.BanDays = 7
+        }
 	if cfg.StatusBanner.WindowMinutes == 0 {
 		cfg.StatusBanner.WindowMinutes = 10
 	}

--- a/api/example config.json
+++ b/api/example config.json
@@ -67,6 +67,13 @@
     "message": "Des perturbations sont en cours.",
     "activated_for_testing": true
   },
+  "spam_protection": {
+    "block_initial_seconds": 60,
+    "block_multiplier": 2,
+    "sanction_threshold": 3,
+    "status_drop": 2,
+    "ban_days": 7
+  },
   "private_news": {
     "password": "change-me",
     "token_hours": 24

--- a/api/main.go
+++ b/api/main.go
@@ -139,8 +139,9 @@ func setupRoutes(r *gin.Engine) {
 	userGroup.POST("/update_password", user.UpdatePasswordHandler)
 	userGroup.GET("/2fa/setup", user.Generate2FAHandler)
 	userGroup.POST("/enable_2fa", user.Enable2FAHandler)
-	userGroup.POST("/disable_2fa", user.Disable2FAHandler)
-	userGroup.POST("/delete", user.DeleteAccountHandler)
+        userGroup.POST("/disable_2fa", user.Disable2FAHandler)
+        userGroup.POST("/delete", user.DeleteAccountHandler)
+        userGroup.GET("/sanctions", user.SanctionsHandler)
 
 	usersGroup := api.Group("/users")
 	usersGroup.GET("/search", user.SearchHandler)

--- a/api/scripts/user/sanctions.go
+++ b/api/scripts/user/sanctions.go
@@ -1,0 +1,59 @@
+package user
+
+import (
+    "database/sql"
+    "net/http"
+
+    "toolcenter/config"
+    "toolcenter/utils"
+
+    "github.com/gin-gonic/gin"
+)
+
+// SanctionsHandler returns all sanctions for the authenticated user.
+func SanctionsHandler(c *gin.Context) {
+    uid, _, _, _, err := utils.Check(c, utils.CheckOpts{RequireToken: true})
+    if err != nil {
+        code := http.StatusInternalServerError
+        if err == utils.ErrMissingToken || err == utils.ErrInvalidToken || err == utils.ErrExpiredToken {
+            code = http.StatusUnauthorized
+        }
+        c.JSON(code, gin.H{"success": false, "message": err.Error()})
+        return
+    }
+
+    db, err := config.OpenDB()
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+        return
+    }
+    defer db.Close()
+
+    rows, err := db.Query(`SELECT sanction_id,type,reason,start_date,end_date FROM user_sanctions WHERE user_id=? ORDER BY start_date DESC`, uid)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+        return
+    }
+    defer rows.Close()
+
+    sanctions := []gin.H{}
+    for rows.Next() {
+        var id int
+        var t, reason string
+        var start, end sql.NullTime
+        if err := rows.Scan(&id, &t, &reason, &start, &end); err == nil {
+            s := gin.H{
+                "sanction_id": id,
+                "type":        t,
+                "reason":      reason,
+                "start_date":  start.Time,
+            }
+            if end.Valid {
+                s["end_date"] = end.Time
+            }
+            sanctions = append(sanctions, s)
+        }
+    }
+
+    c.JSON(http.StatusOK, gin.H{"success": true, "sanctions": sanctions})
+}

--- a/api/utils/email.go
+++ b/api/utils/email.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+    "log"
+    "toolcenter/config"
+    "gopkg.in/gomail.v2"
+)
+
+// SendEmail sends a plain text email using SMTP settings from config.
+func SendEmail(to, subject, body string) error {
+    cfg := config.Get()
+    msg := gomail.NewMessage()
+    msg.SetHeader("From", cfg.Email.From)
+    msg.SetHeader("To", to)
+    msg.SetHeader("Subject", subject)
+    msg.SetBody("text/plain", body)
+
+    d := gomail.NewDialer(cfg.Email.Host, cfg.Email.Port, cfg.Email.Username, cfg.Email.Password)
+    d.SSL = true
+    if err := d.DialAndSend(msg); err != nil {
+        log.Println("send email:", err)
+        return err
+    }
+    return nil
+}

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -338,5 +338,18 @@
     "tags": [
       "backend"
     ]
+  },
+  {
+    "id": 37,
+    "date": "2025-11-15",
+    "displayDate": "15/11/2025",
+    "title": "Sanctions automatiques pour spam",
+    "summary": "Blocage progressif des IP et rétrogradation du statut utilisateur en cas d'abus.",
+    "content": "Le middleware de rate limit gère maintenant des blocs prolongés et applique une baisse de statut configurable. Les utilisateurs trop insistants reçoivent un e-mail et peuvent être bannis automatiquement.",
+    "isNew": true,
+    "isPrivate": true,
+    "tags": [
+      "backend"
+    ]
   }
 ]

--- a/api/utils/rate_limit.go
+++ b/api/utils/rate_limit.go
@@ -1,13 +1,14 @@
 package utils
 
 import (
-	"sync"
-	"time"
+        "sync"
+        "time"
+        "strings"
 
-	"toolcenter/config"
+        "toolcenter/config"
 
-	"github.com/gin-gonic/gin"
-	"golang.org/x/time/rate"
+        "github.com/gin-gonic/gin"
+        "golang.org/x/time/rate"
 )
 
 type limiterEntry struct {
@@ -16,8 +17,10 @@ type limiterEntry struct {
 }
 
 var (
-	rlMu     sync.Mutex
-	ipLimits = make(map[string]*limiterEntry)
+        rlMu     sync.Mutex
+        ipLimits = make(map[string]*limiterEntry)
+        ipBlocks = make(map[string]time.Time)
+        ipAttempts = make(map[string]int)
 )
 
 func getLimiter(ip string) *rate.Limiter {
@@ -44,16 +47,22 @@ func getLimiter(ip string) *rate.Limiter {
 }
 
 func cleanupLimiters() {
-	for {
-		time.Sleep(5 * time.Minute)
-		rlMu.Lock()
-		for ip, entry := range ipLimits {
-			if time.Since(entry.lastSeen) > 10*time.Minute {
-				delete(ipLimits, ip)
-			}
-		}
-		rlMu.Unlock()
-	}
+        for {
+                time.Sleep(5 * time.Minute)
+                rlMu.Lock()
+                for ip, entry := range ipLimits {
+                        if time.Since(entry.lastSeen) > 10*time.Minute {
+                                delete(ipLimits, ip)
+                        }
+                }
+                for ip, until := range ipBlocks {
+                        if time.Now().After(until) {
+                                delete(ipBlocks, ip)
+                                delete(ipAttempts, ip)
+                        }
+                }
+                rlMu.Unlock()
+        }
 }
 
 func init() {
@@ -63,16 +72,70 @@ func init() {
 // RateLimitMiddleware restricts the number of requests per IP
 // based on the RateLimit settings in config.json.
 func RateLimitMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		ip := c.ClientIP()
-		if ip == "" {
-			ip = "unknown"
-		}
-		limiter := getLimiter(ip)
-		if !limiter.Allow() {
-			c.AbortWithStatusJSON(429, gin.H{"success": false, "message": "Trop de requêtes, veuillez patienter."})
-			return
-		}
-		c.Next()
-	}
+        return func(c *gin.Context) {
+                ip := c.ClientIP()
+                if ip == "" {
+                        ip = "unknown"
+                }
+                rlMu.Lock()
+                if until, ok := ipBlocks[ip]; ok && time.Now().Before(until) {
+                        rlMu.Unlock()
+                        c.AbortWithStatusJSON(429, gin.H{"success": false, "message": "Trop de requêtes, veuillez patienter."})
+                        return
+                }
+                rlMu.Unlock()
+                limiter := getLimiter(ip)
+                if !limiter.Allow() {
+                        rlMu.Lock()
+                        ipAttempts[ip]++
+                        attempts := ipAttempts[ip]
+                        cfg := config.Get()
+                        base := cfg.SpamProtection.BlockInitialSeconds
+                        if base <= 0 {
+                                base = 60
+                        }
+                        mult := cfg.SpamProtection.BlockMultiplier
+                        if mult <= 1 {
+                                mult = 2
+                        }
+                        dur := time.Duration(base) * time.Second
+                        for i := 1; i < attempts; i++ {
+                                dur = time.Duration(float64(dur) * mult)
+                        }
+                        ipBlocks[ip] = time.Now().Add(dur)
+                        rlMu.Unlock()
+
+                        if strings.Contains(c.GetHeader("X-Forwarded-For"), ",") {
+                                ipAttempts[ip]++
+                        }
+
+                        if uid, _, _, _, err := Check(c, CheckOpts{RequireToken: true}); err == nil {
+                                thr := cfg.SpamProtection.SanctionThreshold
+                                if thr == 0 {
+                                        thr = 3
+                                }
+                                if attempts >= thr {
+                                        drop := cfg.SpamProtection.StatusDrop
+                                        if drop <= 0 {
+                                                drop = 2
+                                        }
+                                        ApplyStatusDrop(uid, drop)
+                                        db, err := config.OpenDB()
+                                        if err == nil {
+                                                var email string
+                                                _ = db.QueryRow(`SELECT email FROM users WHERE user_id=?`, uid).Scan(&email)
+                                                db.Close()
+                                                if email != "" {
+                                                        _ = SendEmail(email, "Sanction ToolCenter", "Vous avez été sanctionné pour spammer l'API.")
+                                                }
+                                        }
+                                        ipAttempts[ip] = 0
+                                }
+                        }
+
+                        c.AbortWithStatusJSON(429, gin.H{"success": false, "message": "Trop de requêtes, veuillez patienter."})
+                        return
+                }
+                c.Next()
+        }
 }

--- a/api/utils/status.go
+++ b/api/utils/status.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+    "time"
+    "toolcenter/config"
+)
+
+var statusOrder = []string{"Good", "Limited", "Very Limited", "At Risk", "Banned"}
+
+func indexOfStatus(s string) int {
+    for i, v := range statusOrder {
+        if v == s {
+            return i
+        }
+    }
+    return -1
+}
+
+// ApplyStatusDrop decreases a user's account_status by the given number of steps.
+// If the resulting status is "Banned", a temporary ban is recorded.
+func ApplyStatusDrop(userID string, drop int) (string, error) {
+    db, err := config.OpenDB()
+    if err != nil {
+        return "", err
+    }
+    defer db.Close()
+
+    var current string
+    if err := db.QueryRow(`SELECT account_status FROM users WHERE user_id=?`, userID).Scan(&current); err != nil {
+        return "", err
+    }
+    idx := indexOfStatus(current)
+    if idx == -1 {
+        idx = 0
+    }
+    newIdx := idx + drop
+    if newIdx >= len(statusOrder)-1 {
+        // Ban user
+        banDuration := config.Get().SpamProtection.BanDays
+        if banDuration <= 0 {
+            banDuration = 7
+        }
+        end := time.Now().Add(time.Duration(banDuration) * 24 * time.Hour)
+        if _, err := db.Exec(`UPDATE users SET account_status='Banned' WHERE user_id=?`, userID); err != nil {
+            return "", err
+        }
+        _, _ = db.Exec(`INSERT INTO moderation_actions (user_id, action_type, reason, start_date, end_date) VALUES (?, 'Ban', 'Spam', NOW(), ?)`, userID, end)
+        return "Banned", nil
+    }
+    newStatus := statusOrder[newIdx]
+    _, err = db.Exec(`UPDATE users SET account_status=? WHERE user_id=?`, newStatus, userID)
+    return newStatus, err
+}

--- a/frontend/account/test.html
+++ b/frontend/account/test.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ToolCenter - Mon Compte</title>
+    <link rel="icon" href="/assets/tc_logo.webp" type="image/png">
+    <link rel="stylesheet" href="/src/CSS/account/test.css">
+    <link rel="preload" href="/assets/switcher-noir.png" as="image">
+</head>
+<body>
+    <div class="success-modal" id="successModal">
+        <div class="success-modal-content">
+            <img src="/assets/verified-icon.png" alt="Succès" class="success-icon">
+            <h3 class="success-title">Email vérifié !</h3>
+            <p class="success-message">Votre adresse email a été vérifiée avec succès. Vous pouvez maintenant profiter pleinement de votre compte ToolCenter.</p>
+            <button class="success-btn" id="successModalClose">Fermer</button>
+        </div>
+    </div>
+
+    <div class="auth-container" id="authContainer">
+        <div class="auth-card">
+            <h2 class="auth-title">Connectez-vous</h2>
+            <p class="auth-message">Vous devez être connecté pour accéder à cette page. Veuillez vous connecter ou créer un compte.</p>
+            <div class="auth-buttons">
+                <a href="/signin" class="auth-btn auth-btn-primary">Se connecter</a>
+                <a href="/signup" class="auth-btn auth-btn-secondary">Créer un compte</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="main-content-container" id="mainContentContainer">
+        <header id="mainHeader">
+            <div class="left-header">
+                <a href="/" class="logo-link">
+                    <img src="/assets/tc_logo.webp" alt="ToolCenter Logo" class="logo">
+                    <span class="site-title">ToolCenter</span>
+                </a>
+            </div>
+            <div class="right-header">
+                <button class="theme-switcher" id="theme-switcher">
+                    <img src="/assets/switcher.png" alt="Changer de thème" class="theme-icon" id="theme-icon">
+                </button>
+            </div>
+        </header>
+
+        <div class="container" id="mainContainer">
+            <nav class="sidebar">
+                <div class="sidebar-header">
+                    <h3 class="sidebar-title">Navigation</h3>
+                </div>
+                <ul class="sidebar-menu">
+                    <li>
+                        <a href="/" class="active">
+                            <img src="/assets/account.png" alt="Informations" class="sidebar-icon">
+                            Informations du compte
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/account/tools">
+                            <img src="/assets/code.png" alt="Tools" class="sidebar-icon">
+                            Tools Publiés
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/account/security">
+                            <img src="/assets/security-icon.png" alt="Sécurité" class="sidebar-icon">
+                            Sécurité
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/account/preferences">
+                            <img src="/assets/preferences-icon.png" alt="Préférences" class="sidebar-icon">
+                            Préférences
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/account/confidentiality">
+                            <img src="/assets/privacy-icon.png" alt="Confidentialité" class="sidebar-icon">
+                            Confidentialité
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/account/notifications">
+                            <img src="/assets/newsletter.png" alt="Notifications" class="sidebar-icon">
+                            Notifications
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/account/logout">
+                            <img src="/assets/logout.png" alt="Notifications" class="sidebar-icon">
+                            Se déconnecter
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+
+            <div class="main-content">
+                <div class="profile-header">
+                    <h1 class="profile-title">Profil Utilisateur</h1>
+                    <p class="profile-subtitle">Gérez vos informations personnelles, vos paramètres et votre activité sur ToolCenter</p>
+                </div>
+
+                <div id="errorContainer" class="hidden"></div>
+
+                <div class="profile-card" style="padding:0;">
+                    <div class="tabs-header">
+                        <button class="tab-btn active" id="tabMainBtn">Infos principales</button>
+                        <button class="tab-btn" id="tabStatusBtn">Statut du compte</button>
+                    </div>
+                    <div class="tab-content active" id="tabMain">
+                        <div class="profile-info" style="padding:30px;">
+                            <div class="avatar-container">
+                                <div class="skeleton skeleton-avatar" id="skeleton-avatar"></div>
+                                <img src="/assets/account.png" alt="Avatar" class="avatar" id="avatar">
+                                <div class="avatar-edit" id="avatarEditBtn">
+                                    <img src="/assets/edit-icon.png" alt="Modifier" class="avatar-edit-icon">
+                                </div>
+                                <form id="avatarForm" action="/api/upload_avatar.php" method="POST" enctype="multipart/form-data" class="hidden">
+                                    <input type="file" name="avatar" id="avatarInput" accept="image/*">
+                                </form>
+                            </div>
+                            <div class="username-container" style="flex-direction: row; gap:10px;">
+                                <div class="skeleton skeleton-username" id="skeleton-username"></div>
+                                <h2 class="username" id="username">Chargement</h2>
+                                <img src="/assets/verified.png" alt="Vérifié" class="verified-badge" id="verified-badge">
+                                <img src="/assets/edit-icon.png" alt="Modifier" class="username-edit" id="editUsername" title="Modifier l'username" style="width:20px;height:20px;cursor:pointer;">
+                            </div>
+                            <div class="skeleton skeleton-date" id="skeleton-date"></div>
+                            <p class="member-date" id="member-date">Chargement de la date de création...</p>
+                            <div class="email-container">
+                                <div class="skeleton skeleton-email" id="skeleton-email"></div>
+                                <span class="email" id="email">Chargement...</span>
+                                <img src="/assets/show.png" alt="Afficher" class="email-toggle" id="toggleEmail">
+                                <img src="/assets/edit-icon.png" alt="Modifier" class="email-edit" id="editEmail">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tab-content" id="tabStatus" style="padding:30px;">
+                        <h3 style="font-size:1.3rem;margin-bottom:18px;">Statut du compte</h3>
+                        <div id="status-bar-container">
+                            <div class="status-progress-bar" id="statusProgress">
+                                <div class="status-progress" id="statusProgressFill"></div>
+                            </div>
+                            <div class="status-labels">
+                                <span>Tout bon !</span>
+                                <span>Limité</span>
+                                <span>Très limité</span>
+                                <span>À risque</span>
+                                <span>Banni(e)</span>
+                            </div>
+                        </div>
+                        <div style="margin-top:20px;">
+                            <b>Votre statut :</b> <span id="accountStatusText" style="font-weight:bold;">Chargement...</span>
+                        </div>
+                        <div id="statusDescription" style="color:#aaa;margin-top:8px;font-size: 1rem;max-width: 600px;">
+                            Chargemment...
+                        </div>
+                        <div id="sanctionsContainer" style="margin-top:20px;"></div>
+                    </div>
+                </div>
+
+                <div class="stats-container">
+                    <div class="stat-card">
+                        <div class="skeleton skeleton-stat" id="skeleton-stat-1"></div>
+                        <div class="stat-value" id="tools-count">0</div>
+                        <div class="skeleton skeleton-label" id="skeleton-label-1"></div>
+                        <div class="stat-label">Tools Publiés</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="skeleton skeleton-stat" id="skeleton-stat-2"></div>
+                        <div class="stat-value" id="likes-count">0</div>
+                        <div class="skeleton skeleton-label" id="skeleton-label-2"></div>
+                        <div class="stat-label">Likes Reçus</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="skeleton skeleton-stat" id="skeleton-stat-3"></div>
+                        <div class="stat-value" id="views-count">0</div>
+                        <div class="skeleton skeleton-label" id="skeleton-label-3"></div>
+                        <div class="stat-label">Vues Totales</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="skeleton skeleton-stat" id="skeleton-stat-4"></div>
+                        <div class="stat-value" id="followers-count">0</div>
+                        <div class="skeleton skeleton-label" id="skeleton-label-4"></div>
+                        <div class="stat-label">Abonnés</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal-overlay" id="emailModal">
+            <div class="modal">
+                <div class="modal-header">
+                    <h3 class="modal-title">Modifier votre email</h3>
+                    <button class="modal-close" id="closeEmailModal">
+                        <img src="/assets/croix.png" alt="Fermer" class="modal-close-icon">
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="newEmail" class="form-label">Nouvel email</label>
+                        <input type="email" id="newEmail" class="form-input" placeholder="Entrez votre nouvel email">
+                    </div>
+                    <div class="form-group">
+                        <label for="currentPassword" class="form-label">Mot de passe actuel</label>
+                        <input type="password" id="currentPassword" class="form-input" placeholder="Entrez votre mot de passe actuel">
+                    </div>
+                    <div class="form-group" id="email2FAGroup" style="display:none;">
+                        <label for="email2FACode" class="form-label">Code 2FA</label>
+                        <input type="text" id="email2FACode" class="form-input" maxlength="6" placeholder="123456">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" id="cancelEmailChange">Annuler</button>
+                    <button class="btn btn-primary" id="confirmEmailChange">Confirmer</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal-overlay" id="avatarModal">
+            <div class="modal">
+                <div class="modal-header">
+                    <h3 class="modal-title">Confirmer votre nouvel avatar</h3>
+                    <button class="modal-close" id="closeAvatarModal">
+                        <img src="/assets/croix.png" alt="Fermer" class="modal-close-icon">
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="avatar-preview-container">
+                        <img src="" alt="Prévisualisation de l'avatar" class="avatar-preview" id="avatarPreview">
+                        <p>Voulez-vous utiliser cette image comme avatar ?</p>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" id="cancelAvatarChange">Annuler</button>
+                    <button class="btn btn-primary" id="confirmAvatarChange">Confirmer</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal-overlay" id="usernameModal">
+            <div class="modal">
+                <div class="modal-header">
+                    <h3 class="modal-title">Modifier votre pseudo</h3>
+                    <button class="modal-close" id="closeUsernameModal">
+                        <img src="/assets/croix.png" alt="Fermer" class="modal-close-icon">
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="newUsername" class="form-label">Nouveau pseudo</label>
+                        <input type="text" id="newUsername" class="form-input" placeholder="Entrez votre nouveau pseudo">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" id="cancelUsernameChange">Annuler</button>
+                    <button class="btn btn-primary" id="confirmUsernameChange">Confirmer</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module" src="/src/utils/config.js"></script>
+    <script type="module" src="/src/JS/account/test.js"></script>
+</body>
+</html>

--- a/frontend/src/CSS/account/test.css
+++ b/frontend/src/CSS/account/test.css
@@ -1,0 +1,1294 @@
+:root {
+    --primary-color: #3000FF;
+    --primary-hover: #2500cc;
+    --primary-light: rgba(48, 0, 255, 0.1);
+    --dark-bg: #0f0f13;
+    --dark-card: #1a1a23;
+    --dark-text: #f0f0f5;
+    --dark-border: rgba(255, 255, 255, 0.08);
+    --light-bg: #f8f9fa;
+    --light-card: #ffffff;
+    --light-text: #2d3748;
+    --light-border: rgba(0, 0, 0, 0.08);
+    --shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+    --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.05);
+    --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    --radius: 16px;
+    --radius-sm: 8px;
+    --skeleton-color: rgba(255, 255, 255, 0.1);
+    --skeleton-light: rgba(0, 0, 0, 0.05);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', sans-serif;
+    background-color: var(--dark-bg);
+    color: var(--dark-text);
+    min-height: 100vh;
+    transition: var(--transition);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+}
+
+body.light-mode {
+    background-color: var(--light-bg);
+    color: var(--light-text);
+}
+
+.auth-container {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    padding: 20px;
+    text-align: center;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0s 0.3s;
+}
+
+.auth-container.active {
+    display: flex;
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 0.3s ease, visibility 0s;
+}
+
+.auth-card {
+    background-color: var(--dark-card);
+    border-radius: var(--radius);
+    padding: 40px;
+    max-width: 500px;
+    width: 100%;
+    box-shadow: var(--shadow);
+    border: 1px solid var(--dark-border);
+}
+
+.light-mode .auth-card {
+    background-color: var(--light-card);
+    border: 1px solid var(--light-border);
+}
+
+.auth-title {
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin-bottom: 20px;
+    color: var(--primary-color);
+}
+
+.auth-message {
+    margin-bottom: 30px;
+    color: var(--dark-text);
+    opacity: 0.8;
+}
+
+.light-mode .auth-message {
+    color: var(--light-text);
+}
+
+.auth-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.auth-btn {
+    padding: 14px 20px;
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+    text-decoration: none;
+    text-align: center;
+    transition: var(--transition);
+}
+
+.auth-btn-primary {
+    background-color: var(--primary-color);
+    color: white;
+}
+
+.auth-btn-primary:hover {
+    background-color: var(--primary-hover);
+    transform: translateY(-2px);
+}
+
+.auth-btn-secondary {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: var(--dark-text);
+    border: 1px solid var(--dark-border);
+}
+
+.light-mode .auth-btn-secondary {
+    background-color: rgba(0, 0, 0, 0.05);
+    color: var(--light-text);
+    border: 1px solid var(--light-border);
+}
+
+.auth-btn-secondary:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.light-mode .auth-btn-secondary:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.success-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transition: var(--transition);
+    backdrop-filter: blur(5px);
+}
+
+.success-modal.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+.success-modal-content {
+    background-color: var(--dark-card);
+    border-radius: var(--radius);
+    width: 90%;
+    max-width: 500px;
+    padding: 30px;
+    box-shadow: var(--shadow);
+    transform: translateY(20px);
+    transition: var(--transition);
+    border: 1px solid var(--dark-border);
+    text-align: center;
+}
+
+.light-mode .success-modal-content {
+    background-color: var(--light-card);
+    border: 1px solid var(--light-border);
+}
+
+.success-modal.active .success-modal-content {
+    transform: translateY(0);
+}
+
+.success-icon {
+    width: 80px;
+    height: 80px;
+    margin: 0 auto 20px;
+    display: block;
+}
+
+.success-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 15px;
+    color: var(--primary-color);
+}
+
+.success-message {
+    margin-bottom: 25px;
+    color: var(--dark-text);
+}
+
+.light-mode .success-message {
+    color: var(--light-text);
+}
+
+.success-btn {
+    padding: 12px 24px;
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.success-btn:hover {
+    background-color: var(--primary-hover);
+    transform: translateY(-2px);
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 5%;
+    background-color: var(--dark-card);
+    box-shadow: var(--shadow-sm);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    transition: var(--transition);
+    border-bottom: 1px solid var(--dark-border);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0s 0.3s;
+}
+
+header.active {
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 0.3s ease, visibility 0s;
+}
+
+.light-mode header {
+    background-color: var(--light-card);
+    border-bottom: 1px solid var(--light-border);
+}
+
+.logo-link {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    text-decoration: none;
+    padding: 8px 16px;
+    border-radius: 12px;
+    color: var(--dark-text);
+    transition: var(--transition);
+}
+
+.light-mode .logo-link {
+    color: var(--light-text);
+}
+
+.logo-link:hover {
+    background-color: var(--primary-light);
+}
+
+.logo {
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+    transition: var(--transition);
+}
+
+.site-title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    transition: var(--transition);
+}
+
+.theme-switcher {
+    background: none;
+    border: none;
+    cursor: pointer;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: var(--transition);
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.theme-switcher:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    transform: rotate(15deg);
+}
+
+.light-mode .theme-switcher {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.light-mode .theme-switcher:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.theme-icon {
+    width: 20px;
+    height: 20px;
+    transition: var(--transition);
+}
+
+.container {
+    display: flex;
+    width: 100%;
+    max-width: 1200px;
+    margin: 30px auto;
+    padding: 0 5%;
+    gap: 25px;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0s 0.3s;
+}
+
+.main-content-container {
+    display: none;
+}
+
+.main-content-container.active {
+    display: block;
+}
+
+.container.active {
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 0.3s ease, visibility 0s;
+}
+
+.sidebar {
+    width: 280px;
+    background-color: var(--dark-card);
+    border-radius: var(--radius);
+    padding: 16px 0 0px;
+    box-shadow: var(--shadow);
+    transition: var(--transition);
+    height: fit-content;
+    border: 1px solid var(--dark-border);
+}
+
+.light-mode .sidebar {
+    background-color: var(--light-card);
+    border: 1px solid var(--light-border);
+}
+
+.sidebar-header {
+    padding: 0 20px 16px;
+    border-bottom: 1px solid var(--dark-border);
+    margin-bottom: 16px;
+}
+
+.light-mode .sidebar-header {
+    border-bottom: 1px solid var(--light-border);
+}
+
+.sidebar-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--dark-text);
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    opacity: 0.7;
+}
+
+.light-mode .sidebar-title {
+    color: var(--light-text);
+}
+
+.sidebar-menu {
+    list-style: none;
+}
+
+.sidebar-menu li {
+    margin-bottom: 4px;
+}
+
+.sidebar-menu a {
+    display: flex;
+    align-items: center;
+    padding: 12px 20px;
+    color: var(--dark-text);
+    text-decoration: none;
+    font-weight: 500;
+    border-radius: var(--radius-sm);
+    transition: var(--transition);
+    position: relative;
+    font-size: 0.95rem;
+}
+
+.light-mode .sidebar-menu a {
+    color: var(--light-text);
+}
+
+.sidebar-menu a:hover {
+    background-color: var(--primary-light);
+    transform: translateX(4px);
+}
+
+.sidebar-menu a.active {
+    background-color: rgba(48, 0, 255, 0.5);
+    color: rgb(47, 0, 255);
+    font-weight: 600;
+}
+
+.sidebar-menu a::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 3px;
+    background-color: var(--primary-color);
+    border-radius: 0 3px 3px 0;
+    opacity: 0;
+    transition: var(--transition);
+}
+
+.sidebar-menu a:hover::before {
+    opacity: 1;
+}
+
+.sidebar-menu a.active::before {
+    opacity: 1;
+    background-color: rgb(47, 0, 255);
+}
+
+.sidebar-menu a[href*="logout"] {
+    color: #ff0000;
+    font-weight: 600;
+    transition: var(--transition);
+}
+
+.sidebar-menu a[href*="logout"]:hover {
+    background-color: rgba(255, 77, 77, 0.1);
+    transform: translateX(4px);
+}
+
+.sidebar-menu a[href*="logout"]::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 3px;
+    background-color: #ff0000;
+    border-radius: 0 3px 3px 0;
+    opacity: 0;
+    transition: var(--transition);
+}
+
+.sidebar-menu a[href*="logout"]:hover::before {
+    opacity: 1;
+}
+
+.sidebar-icon {
+    width: 18px;
+    height: 18px;
+    margin-right: 12px;
+    opacity: 0.8;
+    transition: var(--transition);
+}
+
+.sidebar-menu a.active .sidebar-icon {
+    opacity: 1;
+}
+
+.main-content {
+    flex-grow: 1;
+    background-color: var(--dark-card);
+    border-radius: var(--radius);
+    padding: 30px;
+    box-shadow: var(--shadow);
+    transition: var(--transition);
+    border: 1px solid var(--dark-border);
+}
+
+.light-mode .main-content {
+    background-color: var(--light-card);
+    border: 1px solid var(--light-border);
+}
+
+.profile-header {
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+.profile-title {
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin-bottom: 8px;
+    color: var(--dark-text);
+    background: linear-gradient(90deg, var(--primary-color), #6a00ff);
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    display: inline-block;
+}
+
+.light-mode .profile-title {
+    background: linear-gradient(90deg, var(--primary-color), #6a00ff);
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.profile-subtitle {
+    color: #aaa;
+    font-size: 1rem;
+    max-width: 500px;
+    margin: 0 auto;
+    line-height: 1.5;
+}
+
+.profile-card {
+    background: linear-gradient(135deg, rgba(48, 0, 255, 0.1) 0%, rgba(48, 0, 255, 0.05) 100%);
+    border-radius: var(--radius);
+    padding: 30px;
+    margin-bottom: 30px;
+    border: 1px solid rgba(48, 0, 255, 0.2);
+    transition: var(--transition);
+    backdrop-filter: blur(10px);
+}
+
+.light-mode .profile-card {
+    background: linear-gradient(135deg, rgba(48, 0, 255, 0.05) 0%, rgba(48, 0, 255, 0.02) 100%);
+    border: 1px solid rgba(48, 0, 255, 0.1);
+}
+
+.profile-info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
+.avatar-container {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    margin-bottom: 10px;
+}
+
+.avatar {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 3px solid var(--primary-color);
+    transition: var(--transition);
+    cursor: pointer;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.avatar.active {
+    opacity: 1;
+}
+
+.avatar:hover {
+    transform: scale(1.05);
+    box-shadow: 0 0 30px rgba(48, 0, 255, 0.4);
+}
+
+.avatar-edit {
+    position: absolute;
+    bottom: 5px;
+    right: 5px;
+    background-color: var(--primary-color);
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: var(--transition);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.avatar-edit:hover {
+    background-color: var(--primary-hover);
+    transform: scale(1.1) rotate(10deg);
+}
+
+.avatar-edit-icon {
+    width: 16px;
+    height: 16px;
+    filter: brightness(0) invert(1);
+}
+
+.username-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0 auto;
+}
+
+.letter{
+    display:inline-block;
+    opacity:0;
+    filter:blur(0px);
+    transform:translateY(-10px);
+    animation:pop .2s forwards;
+    animation-delay:calc(var(--i)*15ms)
+}
+
+@keyframes pop{
+    to{
+        opacity:1;
+        filter:blur(0);
+        transform:translateY(0)
+    }
+}
+
+.username {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--dark-text);
+    letter-spacing: -0.5px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.username.active {
+    opacity: 1;
+}
+
+.light-mode .username {
+    color: var(--light-text);
+}
+
+.verified-badge {
+    width: 20px;
+    height: 20px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.verified-badge.active {
+    opacity: 1;
+    margin-top: 5px;
+    margin-left: 5px;
+    animation: fadeIn 0.3s ease, scaleUp 0.3s ease;
+    transform: translateX(-5px);
+}
+
+@keyframes scaleUp {
+    from {
+    transform: scale(0.9) translateX(0);
+    }
+    to {
+    transform: scale(1) translateX(-5px);
+    }
+}
+
+.member-date {
+    display: none;
+    color: #aaa;
+    font-size: 0.95rem;
+    margin-bottom: 15px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.member-date.active {
+    display: flex;
+    opacity: 0.8;
+}
+
+.email-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background-color: rgba(255, 255, 255, 0.05);
+    padding: 12px 20px;
+    border-radius: 50px;
+    transition: var(--transition);
+    border: 1px solid var(--dark-border);
+    position: relative;
+}
+
+.light-mode .email-container {
+    background-color: rgba(0, 0, 0, 0.05);
+    border: 1px solid var(--light-border);
+}
+
+.email {
+    display: none;
+    font-size: 0.95rem;
+    font-weight: 500;
+    font-family: 'Roboto Mono', monospace;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.email.active {
+    display: flex;
+    opacity: 1;
+}
+
+.email-toggle {
+    display: none;
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    transition: var(--transition);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.email-toggle.active {
+    display: flex;
+    opacity: 0.7;
+}
+
+.email-toggle:hover {
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+.email-edit {
+    display: none;
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    transition: var(--transition);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    margin-left: 8px;
+}
+
+.email-edit.active {
+    display: flex;
+    opacity: 0.7;
+}
+
+.email-edit:hover {
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+.stats-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    margin-top: 30px;
+}
+
+.stat-card {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius);
+    padding: 25px;
+    text-align: center;
+    transition: var(--transition);
+    border: 1px solid var(--dark-border);
+    position: relative;
+    overflow: hidden;
+}
+
+.light-mode .stat-card {
+    background-color: rgba(0, 0, 0, 0.05);
+    border: 1px solid var(--light-border);
+}
+
+.stat-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    border-color: var(--primary-color);
+}
+
+.stat-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 3px;
+    height: 100%;
+    background-color: var(--primary-color);
+    opacity: 0;
+    transition: var(--transition);
+}
+
+.stat-card:hover::before {
+    opacity: 1;
+}
+
+.stat-value {
+    font-size: 2.2rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    margin-bottom: 5px;
+    font-feature-settings: "tnum";
+    font-variant-numeric: tabular-nums;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.stat-value.active {
+    opacity: 1;
+}
+
+.stat-label {
+    font-size: 0.9rem;
+    color: #aaa;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.stat-label.active {
+    opacity: 0.8;
+}
+
+.skeleton {
+    background-color: var(--skeleton-color);
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.skeleton.fade-out {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.skeleton.hidden {
+    opacity: 0;
+    pointer-events: none;
+    display: none;
+}
+
+.light-mode .skeleton {
+    background-color: var(--skeleton-light);
+}
+
+.skeleton::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.05), transparent);
+    animation: shimmer 1.5s infinite;
+}
+
+.light-mode .skeleton::after {
+    background: linear-gradient(90deg, transparent, rgba(0, 0, 0, 0.05), transparent);
+}
+
+.skeleton-avatar {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    margin-bottom: 10px;
+}
+
+.skeleton-username {
+    margin-left: 200px !important;
+    width: 180px;
+    height: 32px;
+    margin: 10px 0;
+}
+
+.skeleton-date {
+    width: 150px;
+    height: 16px;
+    margin-bottom: 15px;
+}
+
+.skeleton-email {
+    width: 200px !important;
+    height: 20px;
+    margin: 0 auto;
+}
+
+.skeleton-stat {
+    width: 60px;
+    height: 40px;
+    margin: 0 auto 8px;
+}
+
+.skeleton-label {
+    width: 100px;
+    height: 12px;
+    margin: 0 auto;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transition: var(--transition);
+    backdrop-filter: blur(5px);
+}
+
+.modal-overlay.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal {
+    background-color: var(--dark-card);
+    border-radius: var(--radius);
+    width: 90%;
+    max-width: 500px;
+    padding: 30px;
+    box-shadow: var(--shadow);
+    transform: translateY(20px);
+    transition: var(--transition);
+    border: 1px solid var(--dark-border);
+}
+
+.light-mode .modal {
+    background-color: var(--light-card);
+    border: 1px solid var(--light-border);
+}
+
+.modal-overlay.active .modal {
+    transform: translateY(0);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.modal-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--dark-text);
+}
+
+.light-mode .modal-title {
+    color: var(--light-text);
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: var(--transition);
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.light-mode .modal-close {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.modal-close:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.light-mode .modal-close:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.modal-close-icon {
+    width: 16px;
+    height: 16px;
+}
+
+.modal-body {
+    margin-bottom: 25px;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 500;
+    color: var(--dark-text);
+}
+
+.light-mode .form-label {
+    color: var(--light-text);
+}
+
+.form-input {
+    width: 100%;
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--dark-border);
+    background-color: rgba(255, 255, 255, 0.05);
+    color: var(--dark-text);
+    font-family: inherit;
+    font-size: 1rem;
+    transition: var(--transition);
+}
+
+.light-mode .form-input {
+    border: 1px solid var(--light-border);
+    background-color: rgba(0, 0, 0, 0.05);
+    color: var(--light-text);
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(48, 0, 255, 0.1);
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.modal-footer .btn:disabled,
+.modal-close:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.spinner {
+    border: 2px solid rgba(255,255,255,0.6);
+    border-top: 2px solid white;
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+    animation: spin 0.6s linear infinite;
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 8px;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.btn {
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    font-weight: 500;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: var(--transition);
+    border: none;
+}
+
+.btn-primary {
+    background-color: var(--primary-color);
+    color: white;
+}
+
+.btn-primary:hover {
+    background-color: var(--primary-hover);
+    transform: translateY(-2px);
+}
+
+.btn-secondary {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: var(--dark-text);
+}
+
+.light-mode .btn-secondary {
+    background-color: rgba(0, 0, 0, 0.05);
+    color: var(--light-text);
+}
+
+.btn-secondary:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.light-mode .btn-secondary:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.avatar-preview-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
+.avatar-preview {
+    width: 180px;
+    height: 180px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 4px solid var(--primary-color);
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
+}
+
+.hidden {
+    display: none;
+}
+
+.error-message {
+    color: #ff4444;
+    background-color: rgba(255, 68, 68, 0.1);
+    padding: 12px;
+    border-radius: var(--radius-sm);
+    margin-bottom: 20px;
+    border: 1px solid rgba(255, 68, 68, 0.3);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.error-icon {
+    width: 20px;
+    height: 20px;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-5px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+    100% { transform: scale(1); }
+}
+
+@keyframes float {
+    0% { transform: translateY(0px); }
+    50% { transform: translateY(-5px); }
+    100% { transform: translateY(0px); }
+}
+
+@keyframes shimmer {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(100%); }
+}
+
+@media (max-width: 992px) {
+    .container {
+        flex-direction: column;
+    }
+
+    .sidebar {
+        width: 100%;
+    }
+}
+
+@media (max-width: 768px) {
+    .profile-title {
+        font-size: 1.5rem;
+    }
+    
+    .username {
+        font-size: 1.5rem;
+    }
+    
+    .profile-card {
+        padding: 20px;
+    }
+}
+
+@media (max-width: 576px) {
+    .stats-container {
+        grid-template-columns: 1fr 1fr;
+    }
+    
+    .profile-header {
+        margin-bottom: 20px;
+    }
+    
+    .avatar-container {
+        width: 100px;
+        height: 100px;
+    }
+    
+    .username {
+        font-size: 1.3rem;
+    }
+    
+    .email-container {
+        padding: 10px 16px;
+    }
+}
+
+@media (max-width: 400px) {
+    .stats-container {
+        grid-template-columns: 1fr;
+    }
+    
+    .stat-card {
+        padding: 20px;
+    }
+}
+
+.tabs-header {
+    display: flex;
+    border-bottom: 1px solid rgba(48,0,255,0.12);
+    background: transparent;
+    border-radius: var(--radius) var(--radius) 0 0;
+    overflow: hidden;
+}
+.tab-btn {
+    flex:1;
+    background: none;
+    border: none;
+    outline: none;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #888;
+    padding: 18px 0;
+    cursor: pointer;
+    transition: background 0.2s, color 0.2s;
+    border-bottom: 3px solid transparent;
+}
+.tab-btn:hover {
+    background: rgba(48,0,255,0.07);
+    color: var(--primary-color);
+}
+.tab-btn.active {
+    background: rgba(48,0,255,0.10);
+    color: var(--primary-color);
+    border-bottom: 3px solid var(--primary-color);
+}
+.tab-content { display:none;}
+.tab-content.active { display:block;}
+.status-progress-bar {
+    width: 100%;
+    background: #232333;
+    height: 18px;
+    border-radius: 10px;
+    margin-bottom: 10px;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 2px 8px #0001;
+    border:1px solid rgba(48,0,255,0.12);
+}
+.status-progress {
+    height: 100%;
+    border-radius: 10px;
+    transition: width 0.6s cubic-bezier(.7,.3,.2,1), background 0.3s;
+    width: 10%;
+    background: linear-gradient(90deg, #10c95a 0%, #ffca29 70%, #e94434 100%);
+    box-shadow: 0 2px 10px #3000ff22;
+}
+.status-labels {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 3px;
+    font-size: .91rem;
+    color: #bbb;
+    opacity: .85;
+}
+.status-labels span {
+    flex:1;text-align:center;
+}
+.username-edit {
+    opacity:.6;
+    transition:opacity .2s;
+}
+.username-edit:hover { opacity:1;}
+
+.sanction { padding:8px;margin-bottom:6px;border-radius:4px; }
+.sanction.active { background:#ffe7e7;color:#b30000; }
+.sanction.expired { background:#f4f4f4;color:#666; }

--- a/frontend/src/JS/account/test.js
+++ b/frontend/src/JS/account/test.js
@@ -1,0 +1,606 @@
+let apiBaseURL = window.API_BASE_URL;
+let currentUserData = null;
+let twoFactorEnabled = false;
+
+document.addEventListener('DOMContentLoaded', () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const emailVerified = urlParams.get('event') === 'email_verified';
+    
+    if (emailVerified) {
+        showSuccessModal("Email vérifié !", "Votre adresse email a été vérifiée avec succès. Vous pouvez maintenant profiter pleinement de votre compte ToolCenter.");
+    }
+    
+    const token = localStorage.getItem('token');
+    
+    if (!token) {
+        showAuthInterface();
+    } else {
+        showMainContent();
+        
+        Promise.resolve()
+            .then(() => fetchUserData())
+            .then(() => {
+                initAvatarModal();
+                initEmailModal();
+                initUsernameModal();
+                initTheme();
+            })
+            .catch(error => {
+                console.error('Erreur:', error);
+                showError("Impossible de se connecter au serveur. Veuillez réessayer plus tard.");
+                setTimeout(() => {
+                    hideMainContent();
+                    showAuthInterface();
+                }, 300);
+            });
+    }
+    
+    const url = new URL(window.location.href);
+    const tok = url.searchParams.get("token");
+    if (tok) {
+        localStorage.setItem("token", tok);
+        url.searchParams.delete("token");
+        history.replaceState({}, "", url);
+        window.location.reload();
+    }
+});
+
+function showAuthInterface() {
+    document.getElementById('authContainer').classList.add('active');
+    document.getElementById('mainContentContainer').classList.remove('active');
+    document.getElementById('mainHeader').classList.remove('active');
+    document.getElementById('mainContainer').classList.remove('active');
+}
+
+function showMainContent() {
+    document.getElementById('authContainer').classList.remove('active');
+    document.getElementById('mainContentContainer').classList.add('active');
+    document.getElementById('mainHeader').classList.add('active');
+    document.getElementById('mainContainer').classList.add('active');
+}
+
+function hideMainContent() {
+    document.getElementById('mainContentContainer').classList.remove('active');
+    document.getElementById('mainHeader').classList.remove('active');
+    document.getElementById('mainContainer').classList.remove('active');
+}
+
+function showError(message) {
+    const errorContainer = document.getElementById('errorContainer');
+    errorContainer.innerHTML = `
+        <div class="error-message">
+            <img src="/assets/error.png" alt="Erreur" class="error-icon">
+            <span>${message}</span>
+        </div>
+    `;
+    errorContainer.classList.remove('hidden');
+}
+
+function showSuccessModal(title, description) {
+    const successModal = document.getElementById('successModal');
+    successModal.classList.add('active');
+
+    const successTitle = document.querySelector('.success-title');
+    const successMessage = document.querySelector('.success-message');
+
+    successTitle.textContent = title;
+    successMessage.textContent = description;
+
+    document.getElementById('successModalClose').addEventListener('click', () => {
+    successModal.classList.remove('active');
+
+    const url = new URL(window.location.href);
+    url.searchParams.delete('event');
+    window.history.replaceState({}, '', url);
+    });
+}
+
+function fetchUserData() {
+    const token = localStorage.getItem('token');
+    
+    return fetch(`${apiBaseURL}/user/me`, {
+        method: 'GET',
+        headers: {
+            'Authorization': `Bearer ${token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            if (response.status === 401) {
+                localStorage.removeItem('token');
+                throw new Error("Votre session a expiré. Veuillez vous reconnecter.");
+            }
+            throw new Error('Erreur lors de la récupération des données utilisateur');
+        }
+        return response.json();
+    })
+    .then(data => {
+        if (data.success) {
+            currentUserData = data.user;
+            twoFactorEnabled = data.user.two_factor_enabled === true;
+            displayUserData(data.user);
+            fetchSanctions();
+            return data;
+        } else {
+            throw new Error(data.message || "Erreur lors de la récupération des données utilisateur");
+        }
+    });
+}
+
+function checkTwoFactorStatus() {
+    const token = localStorage.getItem('token');
+    return fetch(`${apiBaseURL}/user/me`, { headers: { 'Authorization': `Bearer ${token}` } })
+        .then(r => r.json())
+        .then(d => { if (d.success) twoFactorEnabled = d.user.two_factor_enabled === true; });
+}
+
+function displayUserData(userData) {
+    document.querySelectorAll('.skeleton').forEach(el => {
+        el.classList.add('fade-out');
+        setTimeout(() => {
+            setAccountStatus(userData.account_status);
+            el.classList.add('hidden');
+        }, 300);
+    });
+
+    setTimeout(() => {
+        const usernameEl=document.getElementById("username")
+        const name=userData.username
+        usernameEl.textContent=''
+        ;[...name].forEach((ch,i)=>{
+            const span=document.createElement('span')
+            span.textContent=ch
+            span.style.setProperty('--i',i)
+            span.className='letter'
+            usernameEl.appendChild(span)
+        })
+        usernameEl.classList.add('active')
+        
+        const createdAt = new Date(userData.created_at);
+        document.getElementById("member-date").textContent = `Membre depuis ${createdAt.toLocaleDateString('fr-FR')}`;
+        document.getElementById("member-date").classList.add('active');
+        
+        if (userData.avatar_url) {
+            document.getElementById("avatar").src = userData.avatar_url;
+        } else {
+            document.getElementById("avatar").src = "/assets/account.png";
+        }
+        document.getElementById("avatar").classList.add('active');
+
+        const email = userData.email;
+        const [localPart, domain] = email.split("@");
+        const hiddenEmail = localPart.replace(/./g, "*") + "@" + domain;
+
+        document.getElementById("email").textContent = hiddenEmail;
+        document.getElementById("email").dataset.fullEmail = email;
+        document.getElementById("email").classList.add('active');
+        
+        document.getElementById("toggleEmail").classList.add('active');
+        document.getElementById("editEmail").classList.add('active');
+
+        if (userData.is_verified) {
+            document.getElementById("verified-badge").classList.add('active');
+        }
+
+        document.getElementById("tools-count").textContent = userData.stats.tools_posted || 0;
+        document.getElementById("likes-count").textContent = userData.stats.likes_received || 0;
+        document.getElementById("views-count").textContent = "0";
+        document.getElementById("followers-count").textContent = "0";
+        
+        document.querySelectorAll('.stat-value').forEach(el => el.classList.add('active'));
+        document.querySelectorAll('.stat-label').forEach(el => el.classList.add('active'));
+
+        animateCounters();
+
+        document.getElementById('toggleEmail').addEventListener('click', function() {
+            const emailSpan = document.getElementById('email');
+            const isHidden = emailSpan.textContent.includes('*');
+            
+            emailSpan.textContent = isHidden ? emailSpan.dataset.fullEmail : hiddenEmail;
+            this.src = isHidden ? '/assets/dont-show.png' : '/assets/show.png';
+            
+            emailSpan.style.animation = 'none';
+            setTimeout(() => {
+                emailSpan.style.animation = 'fadeIn 0.3s ease';
+            }, 10);
+        });
+    }, 300);
+}
+
+function animateCounters() {
+    const counters = document.querySelectorAll('.stat-value');
+    const speed = 200;
+    
+    counters.forEach(counter => {
+        const target = +counter.innerText;
+        let count = 0;
+        
+        const updateCount = () => {
+            if (count < target) {
+                counter.innerText = Math.ceil(count);
+                count += target / speed;
+                requestAnimationFrame(updateCount);
+            } else {
+                counter.innerText = target;
+            }
+        };
+        
+        updateCount();
+    });
+}
+
+function initTheme() {
+    const themeSwitcher = document.getElementById("theme-switcher");
+    const themeIcon = document.getElementById("theme-icon");
+    const savedTheme = localStorage.getItem("theme");
+
+    if (savedTheme === "light") {
+        document.body.classList.add("light-mode");
+        themeIcon.src = "/assets/switcher-noir.png";
+    } else {
+        themeIcon.src = "/assets/switcher.png";
+    }
+
+    themeSwitcher.addEventListener("click", () => {
+        const isDarkMode = !document.body.classList.contains("light-mode");
+        const newTheme = isDarkMode ? "light" : "dark";
+
+        document.body.classList.toggle("light-mode", newTheme === "light");
+
+        themeIcon.src = newTheme === "dark"
+            ? "/assets/switcher.png"
+            : "/assets/switcher-noir.png";
+
+        localStorage.setItem("theme", newTheme);
+        
+        themeIcon.style.animation = 'none';
+        setTimeout(() => {
+            themeIcon.style.animation = 'float 0.5s ease';
+        }, 10);
+    });
+}
+
+function initEmailModal() {
+    const emailModal = document.getElementById("emailModal");
+    const closeEmailModal = document.getElementById("closeEmailModal");
+    const cancelEmailChange = document.getElementById("cancelEmailChange");
+    const editEmail = document.getElementById("editEmail");
+    const newEmailInput = document.getElementById("newEmail");
+    const currentPasswordInput = document.getElementById("currentPassword");
+    const codeInput = document.getElementById("email2FACode");
+    const confirmEmailChange = document.getElementById("confirmEmailChange");
+
+    editEmail.addEventListener("click", () => {
+        checkTwoFactorStatus().finally(() => {
+            document.getElementById("email2FAGroup").style.display = twoFactorEnabled ? 'block' : 'none';
+            emailModal.classList.add("active");
+            newEmailInput.focus();
+        });
+    });
+    closeEmailModal.addEventListener("click", () => {
+        emailModal.classList.remove("active");
+        newEmailInput.value = "";
+        currentPasswordInput.value = "";
+        codeInput.value = "";
+    });
+    cancelEmailChange.addEventListener("click", () => {
+        emailModal.classList.remove("active");
+        newEmailInput.value = "";
+        currentPasswordInput.value = "";
+        codeInput.value = "";
+    });
+
+    confirmEmailChange.addEventListener("click", () => {
+        const newEmail = newEmailInput.value.trim();
+        const currentPassword = currentPasswordInput.value.trim();
+        const code = codeInput.value.trim();
+
+        if (!newEmail || !currentPassword) {
+            showError("Veuillez remplir tous les champs");
+            return;
+        }
+        if (twoFactorEnabled && code.length !== 6) {
+            showError("Code 2FA invalide");
+            return;
+        }
+
+        const spinner = document.createElement("span");
+        spinner.className = "spinner";
+        confirmEmailChange.prepend(spinner);
+        closeEmailModal.disabled = true;
+        cancelEmailChange.disabled = true;
+        confirmEmailChange.disabled = true;
+        const token = localStorage.getItem("token");
+
+        const payload = { new_email: newEmail, current_password: currentPassword };
+        if (twoFactorEnabled) payload.two_factor_code = code;
+        fetch(`${apiBaseURL}/user/update_email`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`
+        },
+        body: JSON.stringify(payload)
+        })
+        .then(response => response.json())
+        .then(data => {
+        if (data.success) {
+            currentUserData.email = newEmail;
+            document.getElementById("email").textContent = newEmail;
+            document.getElementById("email").dataset.fullEmail = newEmail;
+            emailModal.classList.remove("active");
+            newEmailInput.value = "";
+            currentPasswordInput.value = "";
+            const emailSpan = document.getElementById("email");
+            emailSpan.style.animation = "none";
+            setTimeout(() => {
+            emailSpan.style.animation = "pulse 0.5s ease";
+            }, 10);
+            showSuccessModal("Votre email a été modifié avec succès !", "Vous recevrez un email de confirmation à votre nouvelle adresse.");
+        } else {
+            throw new Error(data.message || "Erreur lors de la modification de l'email");
+        }
+        })
+        .catch(error => {
+            emailModal.classList.remove("active");
+            console.error("Erreur :", error);
+            showError(error.message || "Une erreur s'est produite lors de la modification de l'email");
+        })
+        .finally(() => {
+            closeEmailModal.disabled = false;
+            cancelEmailChange.disabled = false;
+            confirmEmailChange.disabled = false;
+            spinner.remove();
+        });
+    });
+}
+
+function initAvatarModal() {
+    const avatarModal = document.getElementById("avatarModal");
+    const avatarInput = document.getElementById("avatarInput");
+    const avatarPreview = document.getElementById("avatarPreview");
+    const avatarEditBtn = document.getElementById("avatarEditBtn");
+    const closeAvatarModal = document.getElementById("closeAvatarModal");
+    const cancelAvatarChange = document.getElementById("cancelAvatarChange");
+    const confirmAvatarChange = document.getElementById("confirmAvatarChange");
+    const MAX_SIZE = 5 * 1024 * 1024;
+    const ALLOWED_TYPES = ["image/jpeg","image/png","image/webp"];
+    
+    function previewAvatar(event) {
+        const file = event.target.files && event.target.files[0];
+        if (!file) return;
+
+        if (!ALLOWED_TYPES.includes(file.type)) {
+            showError("Format d'image non supporté (jpeg, png ou webp)");
+            avatarModal.classList.remove("active");
+            avatarInput.value = "";
+            return;
+        }
+
+        if (file.size > MAX_SIZE) {
+            showError(`Image trop lourde (max ${MAX_SIZE/(1024*1024)} Mo)`);
+            avatarModal.classList.remove("active");
+            avatarInput.value = "";
+            return;
+        }
+
+        const reader = new FileReader();
+
+        reader.onload = function() {
+            avatarPreview.src = reader.result;
+            avatarModal.classList.add("active");
+        };
+
+        reader.readAsDataURL(file);
+    }
+
+    avatarEditBtn.addEventListener("click", () => {
+        avatarInput.click();
+    });
+    avatarInput.addEventListener("change", previewAvatar);
+    closeAvatarModal.addEventListener("click", () => {
+        avatarModal.classList.remove("active");
+        avatarInput.value = "";
+    });
+    cancelAvatarChange.addEventListener("click", () => {
+        avatarModal.classList.remove("active");
+        avatarInput.value = "";
+    });
+
+    confirmAvatarChange.addEventListener("click", () => {
+        const spinner = document.createElement("span");
+        spinner.className = "spinner";
+        confirmAvatarChange.prepend(spinner);
+        closeAvatarModal.disabled = true;
+        cancelAvatarChange.disabled = true;
+        confirmAvatarChange.disabled = true;
+        const token = localStorage.getItem("token");
+        
+        fetch(avatarPreview.src)
+        .then(res => res.blob())
+        .then(blob => {
+            const formData = new FormData();
+            formData.append("avatar",blob,"avatar.jpg");
+            return fetch(`${apiBaseURL}/user/avatar`, {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`
+                },
+                body: formData
+            });
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                document.getElementById("avatar").src = avatarPreview.src;
+                const avatar = document.getElementById("avatar");
+                avatar.style.animation = "none";
+                setTimeout(() => {
+                    avatar.style.animation = "pulse 0.5s ease";
+                }, 10);
+                showSuccessModal("Votre avatar a été modifié !", "Votre nouvel avatar sera visible sur votre profil et dans vos outils.");
+            } else {
+                const err = new Error(
+                    data.message || "Erreur lors de la modification de l'avatar"
+                );
+                err.retry_at = data.retry_at;
+                throw err;   
+            }
+        })
+        .catch(error => {
+            if (error.retry_at) {
+                const retryAt = new Date(error.retry_at);
+                const now = new Date();
+                const timeDiff = Math.ceil((retryAt - now) / 1000 / 60 / 60);
+                const retryMessage = `Vous ne pouvez changer votre photo de profil qu'une fois par jour. Réessayez dans ${timeDiff} heure(s).`;
+                showError(retryMessage);
+            } else {
+                showError(error.message || "Une erreur s'est produite lors de la modification de l'avatar");
+            }
+        })
+        .finally(() => {
+            closeAvatarModal.disabled = false;
+            cancelAvatarChange.disabled = false;
+            confirmAvatarChange.disabled = false;
+            spinner.remove();
+            avatarModal.classList.remove("active");
+            avatarInput.value = "";
+        });
+    });
+}
+
+// G0
+document.addEventListener('DOMContentLoaded', () => {
+    const tabMainBtn = document.getElementById('tabMainBtn');
+    const tabStatusBtn = document.getElementById('tabStatusBtn');
+    const tabMain = document.getElementById('tabMain');
+    const tabStatus = document.getElementById('tabStatus');
+
+    tabMainBtn.onclick = function() {
+        tabMainBtn.classList.add('active');
+        tabStatusBtn.classList.remove('active');
+        tabMain.classList.add('active');
+        tabStatus.classList.remove('active');
+    }
+    tabStatusBtn.onclick = function() {
+        tabStatusBtn.classList.add('active');
+        tabMainBtn.classList.remove('active');
+        tabStatus.classList.add('active');
+        tabMain.classList.remove('active');
+    }
+});
+
+function initUsernameModal() {
+    const usernameModal = document.getElementById('usernameModal');
+    const newUsernameInput = document.getElementById('newUsername');
+    const closeUsernameModal = document.getElementById('closeUsernameModal');
+    const cancelUsernameChange = document.getElementById('cancelUsernameChange');
+    const confirmUsernameChange = document.getElementById('confirmUsernameChange');
+    const usernameEl = document.getElementById('username');
+    const editBtn = document.getElementById('editUsername');
+
+    editBtn.addEventListener('click', () => {
+        newUsernameInput.value = usernameEl.textContent.trim();
+        usernameModal.classList.add('active');
+        newUsernameInput.focus();
+    });
+
+    function closeModal() {
+        usernameModal.classList.remove('active');
+        newUsernameInput.value = '';
+    }
+
+    closeUsernameModal.addEventListener('click', closeModal);
+    cancelUsernameChange.addEventListener('click', closeModal);
+
+    confirmUsernameChange.addEventListener('click', () => {
+        const newUsername = newUsernameInput.value.trim();
+        if (newUsername.length < 3 || newUsername.length > 50) {
+            showError('Le pseudo doit contenir entre 3 et 50 caractères.');
+            return;
+        }
+
+        const spinner = document.createElement('span');
+        spinner.className = 'spinner';
+        confirmUsernameChange.prepend(spinner);
+        closeUsernameModal.disabled = true;
+        cancelUsernameChange.disabled = true;
+        confirmUsernameChange.disabled = true;
+
+        const token = localStorage.getItem('token');
+        fetch(`${apiBaseURL}/user/update_username`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+            body: JSON.stringify({ username: newUsername })
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data.success) {
+                usernameEl.textContent = newUsername;
+                showSuccessModal('Pseudo modifié !', 'Ton pseudo a été mis à jour !');
+                closeModal();
+            } else {
+                showError(data.message || 'Erreur lors de la modification du pseudo');
+            }
+        })
+        .catch(() => {
+            showError("Impossible de se connecter au serveur. Veuillez réessayer plus tard.");
+        })
+        .finally(() => {
+            closeUsernameModal.disabled = false;
+            cancelUsernameChange.disabled = false;
+            confirmUsernameChange.disabled = false;
+            spinner.remove();
+        });
+    });
+}
+
+function setAccountStatus(status) {
+    const bar = document.getElementById('statusProgressFill');
+    const statusText = document.getElementById('accountStatusText');
+    const statusDesc = document.getElementById('statusDescription');
+    const steps = ['Good','Limited','Very Limited','At Risk','Banned'];
+    const colors = [
+        'linear-gradient(90deg,#10c95a,#2fd174)', // Good
+        'linear-gradient(90deg,#ffca29,#ffd66b)', // Limited
+        'linear-gradient(90deg,#f88407,#ff5f00)', // Very Limited
+        'linear-gradient(90deg,#e94434,#fc6a55)', // At Risk
+        'linear-gradient(90deg,#a10000,#570404)'  // Banned
+    ];
+    const descriptions = [
+        "Merci de respecter les règles de ToolCenter !",
+        "Vous ne pouvez plus utiliser certaines parties de ToolCenter. Vous risquez une suspension si vous enfreignez à nouveau les règles.",
+        "Vous ne pouvez plus utiliser la plupart des parties de ToolCenter. Votre compte pourrait être banni.",
+        "Votre compte est à risque. Vous ne pouvez plus utiliser ToolCenter tant que vous n'avez pas réglé le problème.",
+        "Votre compte est banni. Vous ne pouvez plus utiliser ToolCenter."
+    ];
+    const widths = ['10%','30%','50%','70%','100%'];
+    const idx = steps.indexOf(status);
+    if(idx === -1) return;
+    bar.style.width = widths[idx];
+    bar.style.background = colors[idx];
+    statusText.textContent = steps[idx];
+    statusDesc.textContent = descriptions[idx];
+}
+
+function fetchSanctions() {
+    const token = localStorage.getItem('token');
+    fetch(`${apiBaseURL}/user/sanctions`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+    })
+    .then(r => r.json())
+    .then(d => {
+        if (!d.success) return;
+        const cont = document.getElementById('sanctionsContainer');
+        cont.innerHTML = '';
+        const now = Date.now();
+        d.sanctions.forEach(s => {
+            const end = s.end_date ? new Date(s.end_date).getTime() : null;
+            const active = !end || end > now;
+            const div = document.createElement('div');
+            div.className = active ? 'sanction active' : 'sanction expired';
+            div.textContent = `${s.type} - ${s.reason}` + (end ? ` (jusqu'au ${new Date(end).toLocaleString()})` : '');
+            cont.appendChild(div);
+        });
+    });
+}


### PR DESCRIPTION
## Summary
- add spam protection configuration and middleware enhancements
- lower user status or auto-ban when spamming
- store sanctions and expose `/user/sanctions` endpoint
- send email notifications on sanction
- create `/account/test` page to show active and expired sanctions
- update docs and example config
- document feature in private news

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686eb309dcb48320998f7dababd9e669