### PR TITLE
Add spam protection & sanctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The `moderation` section now includes `auto_unban` to automatically lift tempora
 The `status_banner` section controls the outage banner displayed on the frontend.
 `user_public_tools_limit` defines how many public tools are returned in user search results.
 `rate_limit` sets the maximum number of requests per IP and the time window in seconds.
+`anti_spam` adds progressive blocking and automatic sanctions when the API is spammed.
 Update `frontend/src/utils/config.js` to change the API base URL used by the static pages or set `VITE_API_BASE_URL` in a `.env` file for Vite.
 
 ### Build the frontend with Vite

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -69,10 +69,19 @@ type Config struct {
 	PasswordReset struct {
 		TokenExpiryMinutes int `json:"token_expiry_minutes"`
 	} `json:"password_reset"`
-	RateLimit struct {
-		Requests      int `json:"requests"`
-		WindowSeconds int `json:"window_seconds"`
-	} `json:"rate_limit"`
+        RateLimit struct {
+                Requests      int `json:"requests"`
+                WindowSeconds int `json:"window_seconds"`
+        } `json:"rate_limit"`
+        AntiSpam struct {
+                Enabled            bool    `json:"enabled"`
+                RequestThreshold   int     `json:"request_threshold"`
+                IntervalSeconds    int     `json:"interval_seconds"`
+                InitialBlockSeconds int    `json:"initial_block_seconds"`
+                MaxStrike          int     `json:"max_strike"`
+                StatusDecrease     int     `json:"status_decrease"`
+                BanHours           int     `json:"ban_hours"`
+        } `json:"anti_spam"`
 	StatusBanner struct {
 		ErrorRateThreshold  float64 `json:"error_rate_threshold"`
 		WindowMinutes       int     `json:"window_minutes"`
@@ -133,12 +142,33 @@ func Load(path string) error {
 	if cfg.UserSearchLimit <= 0 || cfg.UserSearchLimit > 20 {
 		cfg.UserSearchLimit = 10
 	}
-	if cfg.UserPublicToolsLimit <= 0 || cfg.UserPublicToolsLimit > 10 {
-		cfg.UserPublicToolsLimit = 3
-	}
-	mu.Lock()
-	Current = cfg
-	mu.Unlock()
+        if cfg.UserPublicToolsLimit <= 0 || cfg.UserPublicToolsLimit > 10 {
+                cfg.UserPublicToolsLimit = 3
+        }
+       if cfg.AntiSpam.RequestThreshold == 0 {
+               cfg.AntiSpam.RequestThreshold = 10
+       }
+       if cfg.AntiSpam.IntervalSeconds == 0 {
+               cfg.AntiSpam.IntervalSeconds = 1
+       }
+       if cfg.AntiSpam.InitialBlockSeconds == 0 {
+               cfg.AntiSpam.InitialBlockSeconds = 30
+       }
+       if cfg.AntiSpam.MaxStrike == 0 {
+               cfg.AntiSpam.MaxStrike = 3
+       }
+       if cfg.AntiSpam.StatusDecrease == 0 {
+               cfg.AntiSpam.StatusDecrease = 2
+       }
+       if cfg.AntiSpam.BanHours == 0 {
+               cfg.AntiSpam.BanHours = 24
+       }
+       if !cfg.AntiSpam.Enabled {
+               cfg.AntiSpam.Enabled = true
+       }
+        mu.Lock()
+        Current = cfg
+        mu.Unlock()
 	return nil
 }
 

--- a/api/example config.json
+++ b/api/example config.json
@@ -60,6 +60,15 @@
     "requests": 60,
     "window_seconds": 60
   },
+  "anti_spam": {
+    "enabled": true,
+    "request_threshold": 10,
+    "interval_seconds": 1,
+    "initial_block_seconds": 30,
+    "max_strike": 3,
+    "status_decrease": 2,
+    "ban_hours": 24
+  },
   "status_banner": {
     "error_rate_threshold": 0.3,
     "window_minutes": 10,

--- a/api/main.go
+++ b/api/main.go
@@ -130,10 +130,11 @@ func setupRoutes(r *gin.Engine) {
 	authGroup.DELETE("/sessions", auth.DeleteAllSessionsHandler)
 	authGroup.DELETE("/sessions/:id", auth.DeleteSessionHandler)
 
-	userGroup := api.Group("/user")
-	userGroup.GET("/verify_email", user.VerifyEmailHandler)
-	userGroup.GET(("/me"), user.MeHandler)
-	userGroup.POST("/avatar", user.UploadAvatar)
+        userGroup := api.Group("/user")
+        userGroup.GET("/verify_email", user.VerifyEmailHandler)
+        userGroup.GET(("/me"), user.MeHandler)
+        userGroup.GET("/sanctions", user.SanctionsHandler)
+        userGroup.POST("/avatar", user.UploadAvatar)
 	userGroup.POST("/update_username", user.UpdateUsernameHandler)
 	userGroup.POST("/update_email", user.UpdateEmailHandler)
 	userGroup.POST("/update_password", user.UpdatePasswordHandler)
@@ -191,11 +192,12 @@ func main() {
 		gin.SetMode(cfg.GinMode)
 	}
 
-	r := gin.Default()
-	r.Use(corsMiddleware())
-	r.Use(utils.RateLimitMiddleware())
-	r.Use(utils.MonitorMiddleware())
-	setupRoutes(r)
+       r := gin.Default()
+       r.Use(corsMiddleware())
+       r.Use(utils.RateLimitMiddleware())
+       r.Use(utils.SpamProtectionMiddleware())
+       r.Use(utils.MonitorMiddleware())
+       setupRoutes(r)
 
 	log.Printf("✅ API ToolCenter démarrée sur le port %d", cfg.Port)
 	r.Run(fmt.Sprintf(":%d", cfg.Port))

--- a/api/scripts/user/sanctions.go
+++ b/api/scripts/user/sanctions.go
@@ -1,0 +1,97 @@
+package user
+
+import (
+    "database/sql"
+    "net/http"
+
+    "toolcenter/config"
+    "toolcenter/utils"
+
+    "github.com/gin-gonic/gin"
+)
+
+func SanctionsHandler(c *gin.Context) {
+    uid, _, _, _, err := utils.Check(c, utils.CheckOpts{RequireToken: true})
+    if err != nil {
+        code := http.StatusInternalServerError
+        if err == utils.ErrMissingToken || err == utils.ErrInvalidToken || err == utils.ErrExpiredToken {
+            code = http.StatusUnauthorized
+        }
+        c.JSON(code, gin.H{"success": false, "message": err.Error()})
+        return
+    }
+
+    db, err := config.OpenDB()
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+        return
+    }
+    defer db.Close()
+
+    type sanction struct {
+        ID     int            `json:"id"`
+        Type   string         `json:"type"`
+        Reason sql.NullString `json:"reason"`
+        Start  sql.NullTime   `json:"start"`
+        End    sql.NullTime   `json:"end"`
+    }
+
+    rows, err := db.Query(`SELECT action_id, action_type, reason, start_date, end_date FROM moderation_actions WHERE user_id=? ORDER BY action_date DESC`, uid)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+        return
+    }
+    defer rows.Close()
+
+    active := make([]gin.H, 0)
+    expired := make([]gin.H, 0)
+    for rows.Next() {
+        var s sanction
+        if err := rows.Scan(&s.ID, &s.Type, &s.Reason, &s.Start, &s.End); err == nil {
+            item := gin.H{"id": s.ID, "type": s.Type}
+            if s.Reason.Valid {
+                item["reason"] = s.Reason.String
+            }
+            if s.Start.Valid {
+                item["start"] = s.Start.Time
+            }
+            if s.End.Valid {
+                item["end"] = s.End.Time
+            }
+            if utils.SanctionActive(s.End) {
+                active = append(active, item)
+            } else {
+                expired = append(expired, item)
+            }
+        }
+    }
+
+    rows2, err := db.Query(`SELECT warn_id, reason, warn_date, expires_at FROM user_warns WHERE user_id=? ORDER BY warn_date DESC`, uid)
+    if err == nil {
+        defer rows2.Close()
+        for rows2.Next() {
+            var id int
+            var reason sql.NullString
+            var start, end sql.NullTime
+            if err := rows2.Scan(&id, &reason, &start, &end); err == nil {
+                item := gin.H{"id": id, "type": "Warn"}
+                if reason.Valid {
+                    item["reason"] = reason.String
+                }
+                if start.Valid {
+                    item["start"] = start.Time
+                }
+                if end.Valid {
+                    item["end"] = end.Time
+                }
+                if utils.SanctionActive(end) {
+                    active = append(active, item)
+                } else {
+                    expired = append(expired, item)
+                }
+            }
+        }
+    }
+
+    c.JSON(http.StatusOK, gin.H{"success": true, "active": active, "expired": expired})
+}

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -333,6 +333,19 @@
     "title": "Protection anti-spam API",
     "summary": "Ajout d'un rate limit configurable pour limiter les requêtes par IP.",
     "content": "Un middleware Go restreint désormais le nombre de requêtes par adresse IP. Les paramètres `requests` et `window_seconds` sont réglables dans `config.json`.",
+  "isNew": true,
+  "isPrivate": true,
+  "tags": [
+    "backend"
+  ]
+  },
+  {
+    "id": 37,
+    "date": "2025-11-05",
+    "displayDate": "05/11/2025",
+    "title": "Sanctions automatiques en cas de spam API",
+    "summary": "Blocages progressifs et baisse du statut si un utilisateur spamme l'API.",
+    "content": "Un middleware détecte les proxys et applique des blocages de plus en plus longs. Après plusieurs avertissements, le statut de l'utilisateur est diminué et un mail est envoyé.",
     "isNew": true,
     "isPrivate": true,
     "tags": [

--- a/api/utils/sanction.go
+++ b/api/utils/sanction.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+    "database/sql"
+    "time"
+)
+
+var statusSteps = []string{"Good", "Limited", "Very Limited", "At Risk", "Banned"}
+
+// DecreaseStatus lowers the user account_status by n steps.
+func DecreaseStatus(db *sql.DB, userID string, n int) (string, error) {
+    var current string
+    if err := db.QueryRow(`SELECT account_status FROM users WHERE user_id=?`, userID).Scan(&current); err != nil {
+        return "", err
+    }
+    idx := 0
+    for i, s := range statusSteps {
+        if s == current {
+            idx = i
+            break
+        }
+    }
+    idx += n
+    if idx >= len(statusSteps) {
+        idx = len(statusSteps) - 1
+    }
+    newStatus := statusSteps[idx]
+    if newStatus != current {
+        if _, err := db.Exec(`UPDATE users SET account_status=? WHERE user_id=?`, newStatus, userID); err != nil {
+            return current, err
+        }
+    }
+    return newStatus, nil
+}
+
+// QueueEmail inserts a message into the email_queue table.
+func QueueEmail(db *sql.DB, to, subject, body string) error {
+    _, err := db.Exec(`INSERT INTO email_queue (to_email, subject, body) VALUES (?, ?, ?)`, to, subject, body)
+    return err
+}
+
+// Helper to compute if a sanction is active given an optional end time.
+func SanctionActive(end sql.NullTime) bool {
+    if !end.Valid {
+        return true
+    }
+    return time.Now().Before(end.Time)
+}
+

--- a/api/utils/spam_protection.go
+++ b/api/utils/spam_protection.go
@@ -1,0 +1,130 @@
+package utils
+
+import (
+    "database/sql"
+    "net/http"
+    "sync"
+    "time"
+
+    "toolcenter/config"
+    "github.com/gin-gonic/gin"
+)
+
+type spamEntry struct {
+    last        time.Time
+    count       int
+    strikes     int
+    blockedUntil time.Time
+}
+
+var (
+    spamMu  sync.Mutex
+    spamMap = make(map[string]*spamEntry)
+)
+
+func isProxy(r *http.Request) bool {
+    if r.Header.Get("X-Forwarded-For") != "" {
+        return true
+    }
+    if r.Header.Get("Via") != "" || r.Header.Get("Forwarded") != "" {
+        return true
+    }
+    return false
+}
+
+// ApplySpamSanction decreases the user status and logs the action.
+func ApplySpamSanction(userID string) {
+    db, err := config.OpenDB()
+    if err != nil {
+        return
+    }
+    defer db.Close()
+    cfg := config.Get()
+    newStatus, err := DecreaseStatus(db, userID, cfg.AntiSpam.StatusDecrease)
+    if err != nil {
+        return
+    }
+    reason := "Abus de l'API (spam)"
+    var end *time.Time
+    if newStatus == "Banned" {
+        t := time.Now().Add(time.Duration(cfg.AntiSpam.BanHours) * time.Hour)
+        end = &t
+    }
+    recordSanction(db, userID, reason, end)
+    var email string
+    _ = db.QueryRow("SELECT email FROM users WHERE user_id=?", userID).Scan(&email)
+    if email != "" {
+        body := "Votre compte a été sanctionné pour spam. Nouveau statut: " + newStatus
+        _ = QueueEmail(db, email, "Sanction ToolCenter", body)
+    }
+}
+
+func recordSanction(db *sql.DB, userID, reason string, end *time.Time) {
+    if end != nil {
+        _, _ = db.Exec(`INSERT INTO moderation_actions (user_id, action_type, reason, start_date, end_date) VALUES (?, 'Ban', ?, NOW(), ?)`, userID, reason, *end)
+    } else {
+        _, _ = db.Exec(`INSERT INTO moderation_actions (user_id, action_type, reason, start_date) VALUES (?, 'Warn', ?, NOW())`, userID, reason)
+    }
+}
+
+// SpamProtectionMiddleware blocks aggressive clients and triggers sanctions on abuse.
+func SpamProtectionMiddleware() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        cfg := config.Get()
+        if !cfg.AntiSpam.Enabled {
+            c.Next()
+            return
+        }
+
+        ip := c.ClientIP()
+        if ip == "" {
+            ip = "unknown"
+        }
+        proxy := isProxy(c.Request)
+        spamMu.Lock()
+        ent, ok := spamMap[ip]
+        if !ok {
+            ent = &spamEntry{}
+            spamMap[ip] = ent
+        }
+        now := time.Now()
+        if ent.blockedUntil.After(now) {
+            spamMu.Unlock()
+            c.AbortWithStatusJSON(429, gin.H{"success": false, "message": "Trop de requêtes, veuillez patienter."})
+            return
+        }
+        interval := time.Duration(cfg.AntiSpam.IntervalSeconds) * time.Second
+        if proxy {
+            interval /= 2
+        }
+        if now.Sub(ent.last) < interval {
+            ent.count++
+        } else {
+            ent.count = 1
+        }
+        ent.last = now
+        if ent.count > cfg.AntiSpam.RequestThreshold {
+            ent.strikes++
+            block := time.Duration(cfg.AntiSpam.InitialBlockSeconds) * time.Second * time.Duration(ent.strikes)
+            if proxy {
+                block *= 2
+            }
+            ent.blockedUntil = now.Add(block)
+            ent.count = 0
+        }
+        strikes := ent.strikes
+        spamMu.Unlock()
+
+        if strikes >= cfg.AntiSpam.MaxStrike {
+            uid, _, _, _, err := Check(c, CheckOpts{RequireToken: true})
+            if err == nil {
+                ApplySpamSanction(uid)
+            }
+            spamMu.Lock()
+            ent.strikes = 0
+            spamMu.Unlock()
+        }
+
+        c.Next()
+    }
+}

--- a/frontend/src/JS/account/test.js
+++ b/frontend/src/JS/account/test.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
         
         Promise.resolve()
             .then(() => fetchUserData())
+            .then(() => fetchSanctions())
             .then(() => {
                 initAvatarModal();
                 initEmailModal();
@@ -590,3 +591,33 @@ function setAccountStatus(status) {
     statusText.textContent = steps[idx];
     statusDesc.textContent = descriptions[idx];
 }
+
+function fetchSanctions() {
+    const token = localStorage.getItem('token');
+    return fetch(`${apiBaseURL}/user/sanctions`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+    })
+    .then(r => r.json())
+    .then(data => {
+        const sk = document.getElementById('skeleton-sanctions');
+        sk.classList.add('fade-out');
+        setTimeout(() => { sk.style.display = 'none'; }, 300);
+        if(!data.success) return;
+        document.querySelector('.sanctions-section').style.display = 'block';
+        const active = document.getElementById('active-sanctions');
+        const expired = document.getElementById('expired-sanctions');
+        active.innerHTML = '';
+        expired.innerHTML = '';
+        data.active.forEach(s => active.appendChild(createSanctionItem(s, false)));
+        data.expired.forEach(s => expired.appendChild(createSanctionItem(s, true)));
+    });
+}
+
+function createSanctionItem(sanction, expired) {
+    const div = document.createElement('div');
+    div.className = 'sanction-item' + (expired ? ' expired' : '');
+    const end = sanction.end ? new Date(sanction.end).toLocaleString('fr-FR') : '';
+    div.textContent = `${sanction.type} - ${sanction.reason || ''}${end ? ' (jusqu\u2019au ' + end + ')' : ''}`;
+    return div;
+}
+


### PR DESCRIPTION
## Summary
- implement anti-spam middleware and status downgrade
- expose `/user/sanctions` endpoint
- display sanctions on account page
- document anti-spam configuration
- update example config and private articles

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f552525908320a2828fd9393c5daa