### PR TITLE
Improve appeals workflow and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ## 🌐 **Quick overview**
 
 **Tool Center** is a web platform designed to:
+
 - 🔧 **Create & publish** your own tools
 - 💬 **Like, comment and share** other people's tools
 - 👤 **Manage your account**: avatar, security, statistics
@@ -32,6 +33,7 @@
 ## 🧠 **Why does Tool Center exist?**
 
 Because the world needed:
+
 - An **open-source hub** for web tools, **without ads** and **without trackers**
 - A place where **indie developers can shine**
 - A **modern** and **fast** site not solely aimed at developers
@@ -41,13 +43,13 @@ Because the world needed:
 
 ## 🧱 **Project architecture**
 
-| 🧩 Part       | ⚙️ Tech stack                        |
-|--------------|--------------------------------------|
-| **Backend API**   | Go (Golang) + MariaDB               |
-| **Frontend**      | HTML, JS, CSS (vanilla)             |
-| **Auth**          | Email with hashed tokens, UUIDv7 IDs, verification, sessions |
-| **Hosting**       | Raspberry Pi 5                      |
-| **Proxy / HTTPS** | Nginx + SSL via Cloudflare          |
+| 🧩 Part           | ⚙️ Tech stack                                                             |
+| ----------------- | ------------------------------------------------------------------------- |
+| **Backend API**   | Go (Golang) + MariaDB                                                     |
+| **Frontend**      | HTML, JS, CSS (vanilla)                                                   |
+| **Auth**          | Email with hashed tokens, UUIDv7 IDs, verification, sessions              |
+| **Hosting**       | Raspberry Pi 5                                                            |
+| **Proxy / HTTPS** | Nginx + SSL via Cloudflare                                                |
 | **Domains**       | [tool-center.fr](https://tool-center.fr) & [gabex.xyz](https://gabex.xyz) |
 
 ---
@@ -66,6 +68,7 @@ The `status_banner` section controls the outage banner displayed on the frontend
 `anti_spam` adds progressive blocking and automatic sanctions when the API is spammed. A new `proxy_multiplier` field lets you tune how much stricter proxy traffic is treated.
 Sanctions can now be contested via the API. Admins review these appeals from the panel.
 When an appeal is processed, the sanction expires and the user's previous status is restored.
+Appeal-related emails now include the appeal ID for easier follow-up and are sent immediately.
 Update `frontend/src/utils/config.js` to change the API base URL used by the static pages or set `VITE_API_BASE_URL` in a `.env` file for Vite.
 
 ### Build the frontend with Vite
@@ -84,6 +87,7 @@ Prototype pages like `frontend/prototypes/index3.html` use Tailwind CSS 4. Run `
 This will generate a `dist` folder containing the static site ready to deploy.
 
 ### Useful API endpoints
+
 - `POST /v{n}/admin/logs/clear` – clear all activity logs
 - `GET /v{n}/admin/users/{id}/tools` – list tools of a specific user
 - `GET /v{n}/admin/users/{id}/ban` – get last ban reason
@@ -110,9 +114,9 @@ curl https://api.tool-center.fr/v1/users/gabex
 
 ## 📸 **Gallery**
 
-| 🔐 Login                             | 📊 Dashboard                        |
-|-------------------------------------|------------------------------------|
-| ![Login](./frontend/public/assets/login-preview.png)        | ![Dashboard](./frontend/public/assets/dashbord-preview.png) |
+| 🔐 Login                                             | 📊 Dashboard                                                |
+| ---------------------------------------------------- | ----------------------------------------------------------- |
+| ![Login](./frontend/public/assets/login-preview.png) | ![Dashboard](./frontend/public/assets/dashbord-preview.png) |
 
 > _Screenshots taken on 2025‑05‑24. The real interface may have evolved since then._
 
@@ -129,6 +133,7 @@ a young full‑stack developer passionate about **AI**, **cybersecurity** and **
 ## ❤️ **Support & Contributions**
 
 **Tool Center** is an **open‑source** project built with:
+
 - 💕 Love
 - ⏱️ Patience and determination
 - ❤️‍🔥 Passion for computing
@@ -147,4 +152,5 @@ Want to contribute or report a bug?
 - 🔐 More security tools and audits
 
 ---
+
 ## **© Gabriel B., 2024-2025 — All rights reserved.**

--- a/api/utils/email.go
+++ b/api/utils/email.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"log"
+	"strings"
+
+	"toolcenter/config"
+
+	gomail "gopkg.in/gomail.v2"
+)
+
+// SendEmail immediately sends an email using SMTP settings from the configuration.
+func SendEmail(to, subject, body string) error {
+	cfg := config.Get()
+	msg := gomail.NewMessage()
+	msg.SetHeader("From", cfg.Email.From)
+	msg.SetHeader("To", to)
+	msg.SetHeader("Subject", subject)
+	ctype := "text/plain"
+	if strings.Contains(body, "<html") {
+		ctype = "text/html"
+	}
+	msg.SetBody(ctype, body)
+
+	d := gomail.NewDialer(cfg.Email.Host, cfg.Email.Port, cfg.Email.Username, cfg.Email.Password)
+	d.SSL = true
+	if err := d.DialAndSend(msg); err != nil {
+		log.Printf("send email to %s failed: %v", to, err)
+		return err
+	}
+	return nil
+}

--- a/api/utils/privates_articles.json
+++ b/api/utils/privates_articles.json
@@ -9,5 +9,16 @@
     "isNew": true,
     "isPrivate": true,
     "tags": ["information"]
+  },
+  {
+    "id": 41,
+    "date": "2026-01-01",
+    "displayDate": "01/01/2026",
+    "title": "Mise à jour contestations",
+    "summary": "Les emails de contestation incluent désormais l'ID et sont envoyés sans délai.",
+    "content": "Les sanctions inactives ne peuvent plus être contestées côté frontend et le panel admin utilise des icônes pour gérer les demandes.",
+    "isNew": true,
+    "isPrivate": true,
+    "tags": ["update"]
   }
 ]

--- a/api/utils/sanction.go
+++ b/api/utils/sanction.go
@@ -32,9 +32,10 @@ func DecreaseStatus(db *sql.DB, userID string, n int) (string, string, error) {
 	return current, newStatus, nil
 }
 
-func QueueEmail(db *sql.DB, to, subject, body string) error {
-	_, err := db.Exec(`INSERT INTO email_queue (to_email, subject, body) VALUES (?, ?, ?)`, to, subject, body)
-	return err
+// QueueEmail now sends the email immediately instead of storing it in a queue.
+// The database parameter is kept for backward compatibility but is unused.
+func QueueEmail(_ *sql.DB, to, subject, body string) error {
+	return SendEmail(to, subject, body)
 }
 
 func SanctionActive(end sql.NullTime) bool {

--- a/frontend/account/index.html
+++ b/frontend/account/index.html
@@ -1,319 +1,586 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ToolCenter - Mon Compte</title>
-    <link rel="icon" href="/assets/tc_logo.webp" type="image/png">
-    <link rel="stylesheet" href="/src/CSS/account/index.css">
-    <link rel="preload" href="/assets/switcher-noir.png" as="image">
-</head>
-<body>
+    <link rel="icon" href="/assets/tc_logo.webp" type="image/png" />
+    <link rel="stylesheet" href="/src/CSS/account/index.css" />
+    <link rel="preload" href="/assets/switcher-noir.png" as="image" />
+  </head>
+  <body>
     <div class="success-modal" id="successModal">
-        <div class="success-modal-content">
-            <img src="/assets/verified-icon.png" alt="Succès" class="success-icon">
-            <h3 class="success-title">Email vérifié !</h3>
-            <p class="success-message">Votre adresse email a été vérifiée avec succès. Vous pouvez maintenant profiter pleinement de votre compte ToolCenter.</p>
-            <button class="success-btn" id="successModalClose">Fermer</button>
-        </div>
+      <div class="success-modal-content">
+        <img
+          src="/assets/verified-icon.png"
+          alt="Succès"
+          class="success-icon"
+        />
+        <h3 class="success-title">Email vérifié !</h3>
+        <p class="success-message">
+          Votre adresse email a été vérifiée avec succès. Vous pouvez maintenant
+          profiter pleinement de votre compte ToolCenter.
+        </p>
+        <button class="success-btn" id="successModalClose">Fermer</button>
+      </div>
     </div>
 
     <div class="auth-container" id="authContainer">
-        <div class="auth-card">
-            <h2 class="auth-title">Connectez-vous</h2>
-            <p class="auth-message">Vous devez être connecté pour accéder à cette page. Veuillez vous connecter ou créer un compte.</p>
-            <div class="auth-buttons">
-                <a href="/signin" class="auth-btn auth-btn-primary">Se connecter</a>
-                <a href="/signup" class="auth-btn auth-btn-secondary">Créer un compte</a>
-            </div>
+      <div class="auth-card">
+        <h2 class="auth-title">Connectez-vous</h2>
+        <p class="auth-message">
+          Vous devez être connecté pour accéder à cette page. Veuillez vous
+          connecter ou créer un compte.
+        </p>
+        <div class="auth-buttons">
+          <a href="/signin" class="auth-btn auth-btn-primary">Se connecter</a>
+          <a href="/signup" class="auth-btn auth-btn-secondary"
+            >Créer un compte</a
+          >
         </div>
+      </div>
     </div>
 
     <div class="main-content-container" id="mainContentContainer">
-        <header id="mainHeader">
-            <div class="left-header">
-                <a href="/" class="logo-link">
-                    <img src="/assets/tc_logo.webp" alt="ToolCenter Logo" class="logo">
-                    <span class="site-title">ToolCenter</span>
-                </a>
+      <header id="mainHeader">
+        <div class="left-header">
+          <a href="/" class="logo-link">
+            <img
+              src="/assets/tc_logo.webp"
+              alt="ToolCenter Logo"
+              class="logo"
+            />
+            <span class="site-title">ToolCenter</span>
+          </a>
+        </div>
+        <div class="right-header">
+          <button class="theme-switcher" id="theme-switcher">
+            <img
+              src="/assets/switcher.png"
+              alt="Changer de thème"
+              class="theme-icon"
+              id="theme-icon"
+            />
+          </button>
+        </div>
+      </header>
+
+      <div class="container" id="mainContainer">
+        <nav class="sidebar">
+          <div class="sidebar-header">
+            <h3 class="sidebar-title">Navigation</h3>
+          </div>
+          <ul class="sidebar-menu">
+            <li>
+              <a href="/account/" class="active">
+                <img
+                  src="/assets/account.png"
+                  alt="Informations"
+                  class="sidebar-icon"
+                />
+                Informations du compte
+              </a>
+            </li>
+            <li>
+              <a href="/account/tools">
+                <img src="/assets/code.png" alt="Tools" class="sidebar-icon" />
+                Tools Publiés
+              </a>
+            </li>
+            <li>
+              <a href="/account/security">
+                <img
+                  src="/assets/security-icon.png"
+                  alt="Sécurité"
+                  class="sidebar-icon"
+                />
+                Sécurité
+              </a>
+            </li>
+            <li>
+              <a href="/account/preferences">
+                <img
+                  src="/assets/preferences-icon.png"
+                  alt="Préférences"
+                  class="sidebar-icon"
+                />
+                Préférences
+              </a>
+            </li>
+            <li>
+              <a href="/account/confidentiality">
+                <img
+                  src="/assets/privacy-icon.png"
+                  alt="Confidentialité"
+                  class="sidebar-icon"
+                />
+                Confidentialité
+              </a>
+            </li>
+            <li>
+              <a href="/account/notifications">
+                <img
+                  src="/assets/newsletter.png"
+                  alt="Notifications"
+                  class="sidebar-icon"
+                />
+                Notifications
+              </a>
+            </li>
+            <li>
+              <a href="/account/logout">
+                <img
+                  src="/assets/logout.png"
+                  alt="Notifications"
+                  class="sidebar-icon"
+                />
+                Se déconnecter
+              </a>
+            </li>
+          </ul>
+        </nav>
+
+        <div class="main-content">
+          <div class="profile-header">
+            <h1 class="profile-title">Profil Utilisateur</h1>
+            <p class="profile-subtitle">
+              Gérez vos informations personnelles, vos paramètres et votre
+              activité sur ToolCenter
+            </p>
+          </div>
+
+          <div id="errorContainer" class="hidden"></div>
+
+          <div class="profile-card" style="padding: 0">
+            <div class="tabs-header">
+              <button class="tab-btn active" id="tabMainBtn">
+                Infos principales
+              </button>
+              <button class="tab-btn" id="tabStatusBtn">
+                Statut du compte
+              </button>
             </div>
-            <div class="right-header">
-                <button class="theme-switcher" id="theme-switcher">
-                    <img src="/assets/switcher.png" alt="Changer de thème" class="theme-icon" id="theme-icon">
+            <div class="tab-content active" id="tabMain">
+              <div class="profile-info" style="padding: 30px">
+                <div class="avatar-container">
+                  <div
+                    class="skeleton skeleton-avatar"
+                    id="skeleton-avatar"
+                  ></div>
+                  <img
+                    src="/assets/account.png"
+                    alt="Avatar"
+                    class="avatar"
+                    id="avatar"
+                  />
+                  <div class="avatar-edit" id="avatarEditBtn">
+                    <img
+                      src="/assets/edit-icon.png"
+                      alt="Modifier"
+                      class="avatar-edit-icon"
+                    />
+                  </div>
+                  <form
+                    id="avatarForm"
+                    action="/api/upload_avatar.php"
+                    method="POST"
+                    enctype="multipart/form-data"
+                    class="hidden"
+                  >
+                    <input
+                      type="file"
+                      name="avatar"
+                      id="avatarInput"
+                      accept="image/*"
+                    />
+                  </form>
+                </div>
+                <div
+                  class="username-container"
+                  style="flex-direction: row; gap: 10px"
+                >
+                  <div
+                    class="skeleton skeleton-username"
+                    id="skeleton-username"
+                  ></div>
+                  <h2 class="username" id="username">Chargement</h2>
+                  <img
+                    src="/assets/verified.png"
+                    alt="Vérifié"
+                    class="verified-badge"
+                    id="verified-badge"
+                  />
+                  <img
+                    src="/assets/edit-icon.png"
+                    alt="Modifier"
+                    class="username-edit"
+                    id="editUsername"
+                    title="Modifier l'username"
+                    style="
+                      width: 20px;
+                      height: 20px;
+                      cursor: pointer;
+                      margin-top: 5px;
+                    "
+                  />
+                </div>
+                <div class="skeleton skeleton-date" id="skeleton-date"></div>
+                <p class="member-date" id="member-date">
+                  Chargement de la date de création...
+                </p>
+                <div class="email-container">
+                  <div
+                    class="skeleton skeleton-email"
+                    id="skeleton-email"
+                  ></div>
+                  <span class="email" id="email">Chargement...</span>
+                  <img
+                    src="/assets/show.png"
+                    alt="Afficher"
+                    class="email-toggle"
+                    id="toggleEmail"
+                  />
+                  <img
+                    src="/assets/edit-icon.png"
+                    alt="Modifier"
+                    class="email-edit"
+                    id="editEmail"
+                  />
+                </div>
+              </div>
+            </div>
+            <div class="tab-content" id="tabStatus" style="padding: 30px">
+              <h3 style="font-size: 1.3rem; margin-bottom: 18px">
+                Statut du compte
+              </h3>
+              <div id="status-bar-container">
+                <div
+                  class="skeleton skeleton-status-bar"
+                  id="skeleton-status-bar"
+                ></div>
+                <div
+                  class="status-progress-bar"
+                  id="statusProgress"
+                  style="display: none"
+                >
+                  <div class="status-progress" id="statusProgressFill"></div>
+                </div>
+                <div class="status-labels">
+                  <span>Tout bon !</span>
+                  <span>Limité</span>
+                  <span>Très limité</span>
+                  <span>À risque</span>
+                  <span>Banni(e)</span>
+                </div>
+              </div>
+              <div
+                style="
+                  margin-top: 20px;
+                  display: flex;
+                  align-items: center;
+                  gap: 5px;
+                "
+              >
+                <b>Votre statut :</b>
+                <div
+                  class="skeleton skeleton-status-text"
+                  id="skeleton-status-text"
+                ></div>
+                <span
+                  id="accountStatusText"
+                  style="font-weight: bold; display: none"
+                  >Chargement...</span
+                >
+              </div>
+              <div
+                id="statusDescription"
+                style="
+                  color: #aaa;
+                  margin-top: 8px;
+                  font-size: 1rem;
+                  max-width: 600px;
+                  display: none;
+                "
+              >
+                Chargement...
+              </div>
+              <div
+                class="skeleton skeleton-status-desc"
+                id="skeleton-status-desc"
+              ></div>
+
+              <div id="sanctions-container" style="margin-top: 30px">
+                <div
+                  class="skeleton skeleton-sanctions"
+                  id="skeleton-sanctions"
+                  style="
+                    height: 150px;
+                    width: 100%;
+                    border-radius: var(--radius);
+                  "
+                ></div>
+
+                <div class="sanctions-section" style="display: none">
+                  <h4
+                    style="
+                      margin-top: 30px;
+                      margin-bottom: 10px;
+                      color: #f77;
+                      border-bottom: 1px solid rgba(255, 119, 119, 0.2);
+                      padding-bottom: 8px;
+                    "
+                  >
+                    Sanctions actives (affectant votre statut)
+                  </h4>
+                  <div id="active-sanctions" class="sanctions-list"></div>
+
+                  <h4
+                    style="
+                      margin-top: 30px;
+                      margin-bottom: 10px;
+                      color: #ccc;
+                      border-bottom: 1px solid rgba(204, 204, 204, 0.2);
+                      padding-bottom: 8px;
+                    "
+                  >
+                    Sanctions expirées
+                  </h4>
+                  <div id="expired-sanctions" class="sanctions-list"></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="modal-overlay" id="sanctionDetailsModal">
+              <div class="modal" style="max-width: 600px">
+                <div class="modal-header">
+                  <h3 class="modal-title" id="sanctionModalTitle">
+                    Détails de la sanction
+                  </h3>
+                  <button class="modal-close" id="closeSanctionModal">
+                    <img
+                      src="/assets/croix.png"
+                      alt="Fermer"
+                      class="modal-close-icon"
+                    />
+                  </button>
+                </div>
+                <div class="modal-body">
+                  <div class="sanction-modal-content">
+                    <div class="sanction-severity" id="sanctionSeverity"></div>
+                    <div class="sanction-reason" id="sanctionReason"></div>
+                    <div class="sanction-date" id="sanctionDate"></div>
+                    <div class="sanction-admin" id="sanctionAdmin"></div>
+
+                    <div class="sanction-restrictions" style="margin-top: 20px">
+                      <h4>Fonctionnalités affectées:</h4>
+                      <ul id="sanctionRestrictions"></ul>
+                    </div>
+
+                    <div class="sanction-additional-info">
+                      <h4>Informations supplémentaires:</h4>
+                      <p id="sanctionAdditionalInfo"></p>
+                    </div>
+                  </div>
+                </div>
+                <div class="modal-footer" id="sanctionModalFooter">
+                  <button
+                    class="btn btn-secondary"
+                    id="appealSanctionBtn"
+                    style="display: none"
+                  >
+                    Contester cette sanction
+                  </button>
+                  <button class="btn btn-primary" id="closeSanctionDetailsBtn">
+                    Fermer
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="modal-overlay" id="appealModal">
+            <div class="modal" style="max-width: 500px">
+              <div class="modal-header">
+                <h3 class="modal-title">Contester cette sanction</h3>
+                <button class="modal-close" id="closeAppealModal">
+                  <img
+                    src="/assets/croix.png"
+                    alt="Fermer"
+                    class="modal-close-icon"
+                  />
                 </button>
+              </div>
+              <div class="modal-body">
+                <textarea
+                  id="appealMessage"
+                  class="form-control"
+                  rows="3"
+                  placeholder="Votre message"
+                ></textarea>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-secondary" id="cancelAppeal">
+                  Annuler
+                </button>
+                <button class="btn btn-primary" id="sendAppeal">Envoyer</button>
+              </div>
             </div>
-        </header>
+          </div>
 
-        <div class="container" id="mainContainer">
-            <nav class="sidebar">
-                <div class="sidebar-header">
-                    <h3 class="sidebar-title">Navigation</h3>
-                </div>
-                <ul class="sidebar-menu">
-                    <li>
-                        <a href="/account/" class="active">
-                            <img src="/assets/account.png" alt="Informations" class="sidebar-icon">
-                            Informations du compte
-                        </a>
-                    </li>
-                    <li>
-                        <a href="/account/tools">
-                            <img src="/assets/code.png" alt="Tools" class="sidebar-icon">
-                            Tools Publiés
-                        </a>
-                    </li>
-                    <li>
-                        <a href="/account/security">
-                            <img src="/assets/security-icon.png" alt="Sécurité" class="sidebar-icon">
-                            Sécurité
-                        </a>
-                    </li>
-                    <li>
-                        <a href="/account/preferences">
-                            <img src="/assets/preferences-icon.png" alt="Préférences" class="sidebar-icon">
-                            Préférences
-                        </a>
-                    </li>
-                    <li>
-                        <a href="/account/confidentiality">
-                            <img src="/assets/privacy-icon.png" alt="Confidentialité" class="sidebar-icon">
-                            Confidentialité
-                        </a>
-                    </li>
-                    <li>
-                        <a href="/account/notifications">
-                            <img src="/assets/newsletter.png" alt="Notifications" class="sidebar-icon">
-                            Notifications
-                        </a>
-                    </li>
-                    <li>
-                        <a href="/account/logout">
-                            <img src="/assets/logout.png" alt="Notifications" class="sidebar-icon">
-                            Se déconnecter
-                        </a>
-                    </li>
-                </ul>
-            </nav>
-
-            <div class="main-content">
-                <div class="profile-header">
-                    <h1 class="profile-title">Profil Utilisateur</h1>
-                    <p class="profile-subtitle">Gérez vos informations personnelles, vos paramètres et votre activité sur ToolCenter</p>
-                </div>
-
-                <div id="errorContainer" class="hidden"></div>
-
-                <div class="profile-card" style="padding:0;">
-                    <div class="tabs-header">
-                        <button class="tab-btn active" id="tabMainBtn">Infos principales</button>
-                        <button class="tab-btn" id="tabStatusBtn">Statut du compte</button>
-                    </div>
-                    <div class="tab-content active" id="tabMain">
-                        <div class="profile-info" style="padding:30px;">
-                            <div class="avatar-container">
-                                <div class="skeleton skeleton-avatar" id="skeleton-avatar"></div>
-                                <img src="/assets/account.png" alt="Avatar" class="avatar" id="avatar">
-                                <div class="avatar-edit" id="avatarEditBtn">
-                                    <img src="/assets/edit-icon.png" alt="Modifier" class="avatar-edit-icon">
-                                </div>
-                                <form id="avatarForm" action="/api/upload_avatar.php" method="POST" enctype="multipart/form-data" class="hidden">
-                                    <input type="file" name="avatar" id="avatarInput" accept="image/*">
-                                </form>
-                            </div>
-                            <div class="username-container" style="flex-direction: row; gap:10px;">
-                                <div class="skeleton skeleton-username" id="skeleton-username"></div>
-                                <h2 class="username" id="username">Chargement</h2>
-                                <img src="/assets/verified.png" alt="Vérifié" class="verified-badge" id="verified-badge">
-                                <img src="/assets/edit-icon.png" alt="Modifier" class="username-edit" id="editUsername" title="Modifier l'username" style="width:20px;height:20px;cursor:pointer;margin-top: 5px;">
-                            </div>
-                            <div class="skeleton skeleton-date" id="skeleton-date"></div>
-                            <p class="member-date" id="member-date">Chargement de la date de création...</p>
-                            <div class="email-container">
-                                <div class="skeleton skeleton-email" id="skeleton-email"></div>
-                                <span class="email" id="email">Chargement...</span>
-                                <img src="/assets/show.png" alt="Afficher" class="email-toggle" id="toggleEmail">
-                                <img src="/assets/edit-icon.png" alt="Modifier" class="email-edit" id="editEmail">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="tab-content" id="tabStatus" style="padding:30px;">
-                        <h3 style="font-size:1.3rem;margin-bottom:18px;">Statut du compte</h3>
-                        <div id="status-bar-container">
-                            <div class="skeleton skeleton-status-bar" id="skeleton-status-bar"></div>
-                            <div class="status-progress-bar" id="statusProgress" style="display: none;">
-                                <div class="status-progress" id="statusProgressFill"></div>
-                            </div>
-                            <div class="status-labels">
-                                <span>Tout bon !</span>
-                                <span>Limité</span>
-                                <span>Très limité</span>
-                                <span>À risque</span>
-                                <span>Banni(e)</span>
-                            </div>
-                        </div>
-                        <div style="margin-top:20px; display: flex; align-items: center; gap: 5px;">
-                            <b>Votre statut :</b> 
-                            <div class="skeleton skeleton-status-text" id="skeleton-status-text"></div>
-                            <span id="accountStatusText" style="font-weight:bold; display: none;">Chargement...</span>
-                        </div>
-                        <div id="statusDescription" style="color:#aaa;margin-top:8px;font-size: 1rem;max-width: 600px; display: none;">
-                            Chargement...
-                        </div>
-                        <div class="skeleton skeleton-status-desc" id="skeleton-status-desc"></div>
-
-                        <div id="sanctions-container" style="margin-top: 30px;">
-                            <div class="skeleton skeleton-sanctions" id="skeleton-sanctions" style="height: 150px; width: 100%; border-radius: var(--radius);"></div>
-                            
-                            <div class="sanctions-section" style="display: none;">
-                                <h4 style="margin-top: 30px; margin-bottom: 10px; color: #f77; border-bottom: 1px solid rgba(255,119,119,0.2); padding-bottom: 8px;">
-                                    Sanctions actives (affectant votre statut)
-                                </h4>
-                                <div id="active-sanctions" class="sanctions-list"></div>
-                                
-                                <h4 style="margin-top: 30px; margin-bottom: 10px; color: #ccc; border-bottom: 1px solid rgba(204,204,204,0.2); padding-bottom: 8px;">
-                                    Sanctions expirées
-                                </h4>
-                                <div id="expired-sanctions" class="sanctions-list"></div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="modal-overlay" id="sanctionDetailsModal">
-                        <div class="modal" style="max-width: 600px;">
-                            <div class="modal-header">
-                                <h3 class="modal-title" id="sanctionModalTitle">Détails de la sanction</h3>
-                                <button class="modal-close" id="closeSanctionModal">
-                                    <img src="/assets/croix.png" alt="Fermer" class="modal-close-icon">
-                                </button>
-                            </div>
-                            <div class="modal-body">
-                                <div class="sanction-modal-content">
-                                    <div class="sanction-severity" id="sanctionSeverity"></div>
-                                    <div class="sanction-reason" id="sanctionReason"></div>
-                                    <div class="sanction-date" id="sanctionDate"></div>
-                                    <div class="sanction-admin" id="sanctionAdmin"></div>
-                                    
-                                    <div class="sanction-restrictions" style="margin-top: 20px;">
-                                        <h4>Fonctionnalités affectées:</h4>
-                                        <ul id="sanctionRestrictions"></ul>
-                                    </div>
-                                    
-                                    <div class="sanction-additional-info" style="margin-top: 20px; padding: 15px; background: rgba(255,255,255,0.05); border-radius: var(--radius-sm);">
-                                        <h4>Informations supplémentaires:</h4>
-                                        <p id="sanctionAdditionalInfo"></p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="modal-footer" id="sanctionModalFooter">
-                                <button class="btn btn-secondary" id="appealSanctionBtn" style="display: none;">Contester cette sanction</button>
-                                <button class="btn btn-primary" id="closeSanctionDetailsBtn">Fermer</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="stats-container">
-                    <div class="stat-card">
-                        <div class="skeleton skeleton-stat" id="skeleton-stat-1"></div>
-                        <div class="stat-value" id="tools-count">0</div>
-                        <div class="skeleton skeleton-label" id="skeleton-label-1"></div>
-                        <div class="stat-label">Tools Publiés</div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="skeleton skeleton-stat" id="skeleton-stat-2"></div>
-                        <div class="stat-value" id="likes-count">0</div>
-                        <div class="skeleton skeleton-label" id="skeleton-label-2"></div>
-                        <div class="stat-label">Likes Reçus</div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="skeleton skeleton-stat" id="skeleton-stat-3"></div>
-                        <div class="stat-value" id="views-count">0</div>
-                        <div class="skeleton skeleton-label" id="skeleton-label-3"></div>
-                        <div class="stat-label">Vues Totales</div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="skeleton skeleton-stat" id="skeleton-stat-4"></div>
-                        <div class="stat-value" id="followers-count">0</div>
-                        <div class="skeleton skeleton-label" id="skeleton-label-4"></div>
-                        <div class="stat-label">Abonnés</div>
-                    </div>
-                </div>
+          <div class="stats-container">
+            <div class="stat-card">
+              <div class="skeleton skeleton-stat" id="skeleton-stat-1"></div>
+              <div class="stat-value" id="tools-count">0</div>
+              <div class="skeleton skeleton-label" id="skeleton-label-1"></div>
+              <div class="stat-label">Tools Publiés</div>
             </div>
+            <div class="stat-card">
+              <div class="skeleton skeleton-stat" id="skeleton-stat-2"></div>
+              <div class="stat-value" id="likes-count">0</div>
+              <div class="skeleton skeleton-label" id="skeleton-label-2"></div>
+              <div class="stat-label">Likes Reçus</div>
+            </div>
+            <div class="stat-card">
+              <div class="skeleton skeleton-stat" id="skeleton-stat-3"></div>
+              <div class="stat-value" id="views-count">0</div>
+              <div class="skeleton skeleton-label" id="skeleton-label-3"></div>
+              <div class="stat-label">Vues Totales</div>
+            </div>
+            <div class="stat-card">
+              <div class="skeleton skeleton-stat" id="skeleton-stat-4"></div>
+              <div class="stat-value" id="followers-count">0</div>
+              <div class="skeleton skeleton-label" id="skeleton-label-4"></div>
+              <div class="stat-label">Abonnés</div>
+            </div>
+          </div>
         </div>
+      </div>
 
-        <div class="modal-overlay" id="emailModal">
-            <div class="modal">
-                <div class="modal-header">
-                    <h3 class="modal-title">Modifier votre email</h3>
-                    <button class="modal-close" id="closeEmailModal">
-                        <img src="/assets/croix.png" alt="Fermer" class="modal-close-icon">
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <div class="form-group">
-                        <label for="newEmail" class="form-label">Nouvel email</label>
-                        <input type="email" id="newEmail" class="form-input" placeholder="Entrez votre nouvel email">
-                    </div>
-                    <div class="form-group">
-                        <label for="currentPassword" class="form-label">Mot de passe actuel</label>
-                        <input type="password" id="currentPassword" class="form-input" placeholder="Entrez votre mot de passe actuel">
-                    </div>
-                    <div class="form-group" id="email2FAGroup" style="display:none;">
-                        <label for="email2FACode" class="form-label">Code 2FA</label>
-                        <input type="text" id="email2FACode" class="form-input" maxlength="6" placeholder="123456">
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-secondary" id="cancelEmailChange">Annuler</button>
-                    <button class="btn btn-primary" id="confirmEmailChange">Confirmer</button>
-                </div>
+      <div class="modal-overlay" id="emailModal">
+        <div class="modal">
+          <div class="modal-header">
+            <h3 class="modal-title">Modifier votre email</h3>
+            <button class="modal-close" id="closeEmailModal">
+              <img
+                src="/assets/croix.png"
+                alt="Fermer"
+                class="modal-close-icon"
+              />
+            </button>
+          </div>
+          <div class="modal-body">
+            <div class="form-group">
+              <label for="newEmail" class="form-label">Nouvel email</label>
+              <input
+                type="email"
+                id="newEmail"
+                class="form-input"
+                placeholder="Entrez votre nouvel email"
+              />
             </div>
+            <div class="form-group">
+              <label for="currentPassword" class="form-label"
+                >Mot de passe actuel</label
+              >
+              <input
+                type="password"
+                id="currentPassword"
+                class="form-input"
+                placeholder="Entrez votre mot de passe actuel"
+              />
+            </div>
+            <div class="form-group" id="email2FAGroup" style="display: none">
+              <label for="email2FACode" class="form-label">Code 2FA</label>
+              <input
+                type="text"
+                id="email2FACode"
+                class="form-input"
+                maxlength="6"
+                placeholder="123456"
+              />
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-secondary" id="cancelEmailChange">
+              Annuler
+            </button>
+            <button class="btn btn-primary" id="confirmEmailChange">
+              Confirmer
+            </button>
+          </div>
         </div>
+      </div>
 
-        <div class="modal-overlay" id="avatarModal">
-            <div class="modal">
-                <div class="modal-header">
-                    <h3 class="modal-title">Confirmer votre nouvel avatar</h3>
-                    <button class="modal-close" id="closeAvatarModal">
-                        <img src="/assets/croix.png" alt="Fermer" class="modal-close-icon">
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <div class="avatar-preview-container">
-                        <img src="" alt="Prévisualisation de l'avatar" class="avatar-preview" id="avatarPreview">
-                        <p>Voulez-vous utiliser cette image comme avatar ?</p>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-secondary" id="cancelAvatarChange">Annuler</button>
-                    <button class="btn btn-primary" id="confirmAvatarChange">Confirmer</button>
-                </div>
+      <div class="modal-overlay" id="avatarModal">
+        <div class="modal">
+          <div class="modal-header">
+            <h3 class="modal-title">Confirmer votre nouvel avatar</h3>
+            <button class="modal-close" id="closeAvatarModal">
+              <img
+                src="/assets/croix.png"
+                alt="Fermer"
+                class="modal-close-icon"
+              />
+            </button>
+          </div>
+          <div class="modal-body">
+            <div class="avatar-preview-container">
+              <img
+                src=""
+                alt="Prévisualisation de l'avatar"
+                class="avatar-preview"
+                id="avatarPreview"
+              />
+              <p>Voulez-vous utiliser cette image comme avatar ?</p>
             </div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-secondary" id="cancelAvatarChange">
+              Annuler
+            </button>
+            <button class="btn btn-primary" id="confirmAvatarChange">
+              Confirmer
+            </button>
+          </div>
         </div>
+      </div>
 
-        <div class="modal-overlay" id="usernameModal">
-            <div class="modal">
-                <div class="modal-header">
-                    <h3 class="modal-title">Modifier votre pseudo</h3>
-                    <button class="modal-close" id="closeUsernameModal">
-                        <img src="/assets/croix.png" alt="Fermer" class="modal-close-icon">
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <div class="form-group">
-                        <label for="newUsername" class="form-label">Nouveau pseudo</label>
-                        <input type="text" id="newUsername" class="form-input" placeholder="Entrez votre nouveau pseudo">
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-secondary" id="cancelUsernameChange">Annuler</button>
-                    <button class="btn btn-primary" id="confirmUsernameChange">Confirmer</button>
-                </div>
+      <div class="modal-overlay" id="usernameModal">
+        <div class="modal">
+          <div class="modal-header">
+            <h3 class="modal-title">Modifier votre pseudo</h3>
+            <button class="modal-close" id="closeUsernameModal">
+              <img
+                src="/assets/croix.png"
+                alt="Fermer"
+                class="modal-close-icon"
+              />
+            </button>
+          </div>
+          <div class="modal-body">
+            <div class="form-group">
+              <label for="newUsername" class="form-label">Nouveau pseudo</label>
+              <input
+                type="text"
+                id="newUsername"
+                class="form-input"
+                placeholder="Entrez votre nouveau pseudo"
+              />
             </div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-secondary" id="cancelUsernameChange">
+              Annuler
+            </button>
+            <button class="btn btn-primary" id="confirmUsernameChange">
+              Confirmer
+            </button>
+          </div>
         </div>
+      </div>
     </div>
 
     <script type="module" src="/src/utils/config.js"></script>
     <script type="module" src="/src/JS/account/index.js"></script>
-</body>
+  </body>
 </html>

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -1,138 +1,171 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ToolCenter - Admin Panel</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link rel="stylesheet" href="/src/CSS/admin/index.css">
-  <link rel="icon" href="/assets/tc_logo.webp" type="image/png">
-</head>
-<body>
-  <div id="preloader">
-    <div class="spinner"></div>
-    <div id="preloader-message">Vérification des permissions...</div>
-  </div>
-
-  <header class="admin-header">
-    <h1>
-      <img src="/assets/tc_logo.webp" alt="ToolCenter" class="logo">
-      ToolCenter <span>Admin</span>
-    </h1>
-    <nav class="admin-nav">
-      <a href="/" class="active">
-        <i class="fas fa-tachometer-alt"></i>
-        Acceuil
-      </a>
-      <button class="theme-toggle" id="theme-toggle">
-        <i class="fas fa-moon"></i>
-      </button>
-      <img src="/assets/account.png" alt="Admin" class="user-avatar" id="admin-avatar">
-    </nav>
-  </header>
-
-  <div class="admin-sidebar">
-    <a href="#" class="sidebar-item active">
-      <i class="fas fa-tachometer-alt"></i>
-      Tableau de bord
-    </a>
-    <a href="/admin/users" class="sidebar-item">
-      <i class="fas fa-users"></i>
-      Utilisateurs
-    </a>
-    <a href="/admin/mods" class="sidebar-item">
-      <i class="fas fa-user-shield"></i>
-      Modérateurs
-    </a>
-    <a href="/admin/logs" class="sidebar-item">
-      <i class="fas fa-clipboard-list"></i>
-      Logs système
-    </a>
-    <a href="/admin/tools" class="sidebar-item">
-      <i class="fas fa-tools"></i>
-      Outils
-    </a>
-    <a href="/admin/reports" class="sidebar-item">
-      <i class="fas fa-flag"></i>
-      Signalements
-    </a>
-    <a href="/admin/appeals" class="sidebar-item" data-path="/admin/appeals">
-      <i class="fas fa-gavel"></i>
-      Contestations
-    </a>
-    <a href="/admin/params" class="sidebar-item">
-      <i class="fas fa-cog"></i>
-      Paramètres
-    </a>
-    
-    <div class="sidebar-footer">
-      <a href="/account/logout" class="sidebar-item">
-        <i class="fas fa-sign-out-alt"></i>
-        Déconnexion
-      </a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ToolCenter - Admin Panel</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link rel="stylesheet" href="/src/CSS/admin/index.css" />
+    <link rel="icon" href="/assets/tc_logo.webp" type="image/png" />
+  </head>
+  <body>
+    <div id="preloader">
+      <div class="spinner"></div>
+      <div id="preloader-message">Vérification des permissions...</div>
     </div>
-  </div>
 
-  <main class="admin-content" id="admin-content">
-  </main>
+    <header class="admin-header">
+      <h1>
+        <img src="/assets/tc_logo.webp" alt="ToolCenter" class="logo" />
+        ToolCenter <span>Admin</span>
+      </h1>
+      <nav class="admin-nav">
+        <a href="/" class="active">
+          <i class="fas fa-tachometer-alt"></i>
+          Acceuil
+        </a>
+        <button class="theme-toggle" id="theme-toggle">
+          <i class="fas fa-moon"></i>
+        </button>
+        <img
+          src="/assets/account.png"
+          alt="Admin"
+          class="user-avatar"
+          id="admin-avatar"
+        />
+      </nav>
+    </header>
 
-  <div class="modal-overlay" id="user-modal">
-    <div class="user-modal">
-      <div class="modal-header">
-        <h3 class="modal-title">
-          <i class="fas fa-user"></i>
-          Détails de l'utilisateur
-        </h3>
-        <button class="close-modal" id="close-modal">&times;</button>
+    <div class="admin-sidebar">
+      <a href="#" class="sidebar-item active">
+        <i class="fas fa-tachometer-alt"></i>
+        Tableau de bord
+      </a>
+      <a href="/admin/users" class="sidebar-item">
+        <i class="fas fa-users"></i>
+        Utilisateurs
+      </a>
+      <a href="/admin/mods" class="sidebar-item">
+        <i class="fas fa-user-shield"></i>
+        Modérateurs
+      </a>
+      <a href="/admin/logs" class="sidebar-item">
+        <i class="fas fa-clipboard-list"></i>
+        Logs système
+      </a>
+      <a href="/admin/tools" class="sidebar-item">
+        <i class="fas fa-tools"></i>
+        Outils
+      </a>
+      <a href="/admin/reports" class="sidebar-item">
+        <i class="fas fa-flag"></i>
+        Signalements
+      </a>
+      <a href="/admin/appeals" class="sidebar-item" data-path="/admin/appeals">
+        <i class="fas fa-gavel"></i>
+        Contestations
+      </a>
+      <a href="/admin/params" class="sidebar-item">
+        <i class="fas fa-cog"></i>
+        Paramètres
+      </a>
+
+      <div class="sidebar-footer">
+        <a href="/account/logout" class="sidebar-item">
+          <i class="fas fa-sign-out-alt"></i>
+          Déconnexion
+        </a>
       </div>
-      <div class="modal-body">
-        <div class="user-profile-header">
-          <img src="/assets/account.png" alt="User" class="user-avatar-lg" id="modal-avatar">
-          <div class="user-details">
-            <div class="user-name-wrapper">
-              <h2 class="user-name-lg" id="modal-user-name">Chargement...</h2>
-              <img src="/assets/verified.png" id="modal-verified" title="Vérifié" class="verified-icon" style="display:none; margin-bottom: 3px;">
-              <span class="user-role role-user" id="modal-user-role">Utilisateur</span>
-            </div>
-            <div class="user-stats">
-              <div class="user-stat">
-                <div class="stat-number" id="tools-count">0</div>
-                <div class="stat-label">Outils</div>
+    </div>
+
+    <main class="admin-content" id="admin-content"></main>
+
+    <div class="modal-overlay" id="user-modal">
+      <div class="user-modal">
+        <div class="modal-header">
+          <h3 class="modal-title">
+            <i class="fas fa-user"></i>
+            Détails de l'utilisateur
+          </h3>
+          <button class="close-modal" id="close-modal">&times;</button>
+        </div>
+        <div class="modal-body">
+          <div class="user-profile-header">
+            <img
+              src="/assets/account.png"
+              alt="User"
+              class="user-avatar-lg"
+              id="modal-avatar"
+            />
+            <div class="user-details">
+              <div class="user-name-wrapper">
+                <h2 class="user-name-lg" id="modal-user-name">Chargement...</h2>
+                <img
+                  src="/assets/verified.png"
+                  id="modal-verified"
+                  title="Vérifié"
+                  class="verified-icon"
+                  style="display: none; margin-bottom: 3px"
+                />
+                <span class="user-role role-user" id="modal-user-role"
+                  >Utilisateur</span
+                >
               </div>
-              <div class="user-stat">
-                <div class="stat-number" id="reports-count">0</div>
-                <div class="stat-label">Signalements</div>
+              <div class="user-stats">
+                <div class="user-stat">
+                  <div class="stat-number" id="tools-count">0</div>
+                  <div class="stat-label">Outils</div>
+                </div>
+                <div class="user-stat">
+                  <div class="stat-number" id="reports-count">0</div>
+                  <div class="stat-label">Signalements</div>
+                </div>
+                <div class="user-stat">
+                  <div class="stat-number" id="joined-date">--/--/----</div>
+                  <div class="stat-label">Inscription</div>
+                </div>
               </div>
-              <div class="user-stat">
-              <div class="stat-number" id="joined-date">--/--/----</div>
-              <div class="stat-label">Inscription</div>
+              <div id="ban-info" class="ban-info" style="display: none"></div>
             </div>
           </div>
-          <div id="ban-info" class="ban-info" style="display:none;"></div>
-        </div>
-        </div>
 
-        <div class="user-tabs">
-          <div class="user-tab active" data-tab="info">Informations</div>
-          <div class="user-tab" data-tab="activity">Activité</div>
-          <div class="user-tab" data-tab="tools">Outils</div>
-          <div class="user-tab" data-tab="settings">Paramètres</div>
-        </div>
+          <div class="user-tabs">
+            <div class="user-tab active" data-tab="info">Informations</div>
+            <div class="user-tab" data-tab="activity">Activité</div>
+            <div class="user-tab" data-tab="tools">Outils</div>
+            <div class="user-tab" data-tab="settings">Paramètres</div>
+          </div>
 
-        <div class="tab-content active" id="info-tab">
-          <div class="form-row">
-            <!-- Champ nom complet retiré car absent de la base -->
+          <div class="tab-content active" id="info-tab">
+            <div class="form-row">
+              <!-- Champ nom complet retiré car absent de la base -->
+              <div class="form-group">
+                <label>Nom d'utilisateur</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="username"
+                  placeholder="Chargement..."
+                />
+              </div>
+            </div>
             <div class="form-group">
-              <label>Nom d'utilisateur</label>
-              <input type="text" class="form-control" id="username" placeholder="Chargement...">
+              <label>Email</label>
+              <input
+                type="email"
+                class="form-control"
+                id="email"
+                placeholder="Chargement..."
+              />
             </div>
-          </div>
-          <div class="form-group">
-            <label>Email</label>
-            <input type="email" class="form-control" id="email" placeholder="Chargement...">
-          </div>
-          <!-- Champs personnels non disponibles dans l'API
+            <!-- Champs personnels non disponibles dans l'API
           <div class="form-row">
             <div class="form-group">
               <label>Date de naissance</label>
@@ -144,82 +177,133 @@
             </div>
           </div>
           -->
-          <div class="form-group">
-            <label>Bio</label>
-            <textarea class="form-control" id="bio" rows="3" placeholder="Chargement..."></textarea>
+            <div class="form-group">
+              <label>Bio</label>
+              <textarea
+                class="form-control"
+                id="bio"
+                rows="3"
+                placeholder="Chargement..."
+              ></textarea>
+            </div>
+          </div>
+
+          <div class="tab-content" id="activity-tab">
+            <div
+              class="skeleton"
+              style="height: 300px; border-radius: 8px"
+            ></div>
+          </div>
+
+          <div class="tab-content" id="tools-tab">
+            <div
+              class="skeleton"
+              style="height: 300px; border-radius: 8px"
+            ></div>
+          </div>
+
+          <div class="tab-content" id="settings-tab">
+            <div class="form-group">
+              <label>Rôle</label>
+              <select class="form-control" id="user-role">
+                <option value="User">Utilisateur</option>
+                <option value="Moderator">Modérateur</option>
+                <option value="Admin">Administrateur</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>Status du compte</label>
+              <select class="form-control" id="account-status">
+                <option value="Good">Actif</option>
+                <option value="Limited">Limité</option>
+                <option value="Very Limited">Très limité</option>
+                <option value="At Risk">À risque</option>
+                <option value="Banned">Banni</option>
+              </select>
+            </div>
+            <!-- Champs supplémentaires retirés car non gérés par l'API -->
           </div>
         </div>
-
-        <div class="tab-content" id="activity-tab">
-          <div class="skeleton" style="height: 300px; border-radius: 8px;"></div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" id="cancel-changes">
+            <i class="fas fa-times"></i> Annuler
+          </button>
+          <button class="btn btn-danger" id="ban-user">
+            <i class="fas fa-ban"></i> Bannir
+          </button>
+          <button class="btn btn-primary" id="save-changes">
+            <i class="fas fa-save"></i> Enregistrer
+          </button>
         </div>
-
-        <div class="tab-content" id="tools-tab">
-          <div class="skeleton" style="height: 300px; border-radius: 8px;"></div>
-        </div>
-
-        <div class="tab-content" id="settings-tab">
-          <div class="form-group">
-            <label>Rôle</label>
-            <select class="form-control" id="user-role">
-              <option value="User">Utilisateur</option>
-              <option value="Moderator">Modérateur</option>
-              <option value="Admin">Administrateur</option>
-            </select>
-          </div>
-          <div class="form-group">
-            <label>Status du compte</label>
-            <select class="form-control" id="account-status">
-              <option value="Good">Actif</option>
-              <option value="Limited">Limité</option>
-              <option value="Very Limited">Très limité</option>
-              <option value="At Risk">À risque</option>
-              <option value="Banned">Banni</option>
-            </select>
-          </div>
-          <!-- Champs supplémentaires retirés car non gérés par l'API -->
-        </div>
-  </div>
-  <div class="modal-footer">
-    <button class="btn btn-secondary" id="cancel-changes">
-      <i class="fas fa-times"></i> Annuler
-    </button>
-    <button class="btn btn-danger" id="ban-user">
-      <i class="fas fa-ban"></i> Bannir
-    </button>
-    <button class="btn btn-primary" id="save-changes">
-      <i class="fas fa-save"></i> Enregistrer
-    </button>
-  </div>
-</div>
-</div>
-
-<div class="modal-overlay" id="ban-modal">
-  <div class="confirm-modal">
-    <div class="modal-header">
-      <h3 class="modal-title" id="ban-modal-title">Bannir l'utilisateur</h3>
-      <button class="close-modal" id="close-ban-modal">&times;</button>
-    </div>
-    <div class="modal-body">
-      <div class="form-group ban-reason-group">
-        <label for="ban-reason">Raison du ban</label>
-        <textarea id="ban-reason" class="form-control" rows="3" placeholder="Indiquez la raison" style="resize: vertical;"></textarea>
-        <label for="ban-duration">Durée (heures, 0 = permanent)</label>
-        <input type="number" id="ban-duration" class="form-control" min="0" value="24">
       </div>
-      <p id="unban-text" class="hidden">Voulez-vous vraiment débannir cet utilisateur ?</p>
     </div>
-    <div class="modal-footer">
-      <button class="btn btn-secondary" id="cancel-ban"><i class="fas fa-times"></i>Annuler</button>
-      <button class="btn btn-danger" id="confirm-ban">Confirmer</button>
-    </div>
-  </div>
-</div>
 
-<div class="toast-container" id="toast-container">
-</div>
-  <script type="module" src="/src/utils/panel-config.js"></script>
-  <script type="module" src="/src/utils/config.js"></script>
-  <script type="module" src="/src/JS/admin/index.js"></script>
-</body>
+    <div class="modal-overlay" id="ban-modal">
+      <div class="confirm-modal">
+        <div class="modal-header">
+          <h3 class="modal-title" id="ban-modal-title">Bannir l'utilisateur</h3>
+          <button class="close-modal" id="close-ban-modal">&times;</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-group ban-reason-group">
+            <label for="ban-reason">Raison du ban</label>
+            <textarea
+              id="ban-reason"
+              class="form-control"
+              rows="3"
+              placeholder="Indiquez la raison"
+              style="resize: vertical"
+            ></textarea>
+            <label for="ban-duration">Durée (heures, 0 = permanent)</label>
+            <input
+              type="number"
+              id="ban-duration"
+              class="form-control"
+              min="0"
+              value="24"
+            />
+          </div>
+          <p id="unban-text" class="hidden">
+            Voulez-vous vraiment débannir cet utilisateur ?
+          </p>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" id="cancel-ban">
+            <i class="fas fa-times"></i>Annuler
+          </button>
+          <button class="btn btn-danger" id="confirm-ban">Confirmer</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal-overlay" id="appeal-modal">
+      <div class="confirm-modal">
+        <div class="modal-header">
+          <h3 class="modal-title">Message pour l'utilisateur</h3>
+          <button class="close-modal" id="close-appeal-modal">&times;</button>
+        </div>
+        <div class="modal-body">
+          <textarea
+            id="appeal-message"
+            class="form-control"
+            rows="3"
+            placeholder="Message"
+          ></textarea>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" id="cancel-appeal">
+            <i class="fas fa-times"></i>
+          </button>
+          <button class="btn btn-primary" id="confirm-appeal">
+            <i class="fas fa-check"></i>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast-container" id="toast-container"></div>
+    <script type="module" src="/src/utils/panel-config.js"></script>
+    <script type="module" src="/src/utils/config.js"></script>
+    <script type="module" src="/src/JS/admin/index.js"></script>
+  </body>
 </html>

--- a/frontend/src/CSS/account/index.css
+++ b/frontend/src/CSS/account/index.css
@@ -1,1317 +1,1399 @@
 :root {
-    --primary-color: #3000FF;
-    --primary-hover: #2500cc;
-    --primary-light: rgba(48, 0, 255, 0.1);
-    --dark-bg: #0f0f13;
-    --dark-card: #1a1a23;
-    --dark-text: #f0f0f5;
-    --dark-border: rgba(255, 255, 255, 0.08);
-    --light-bg: #f8f9fa;
-    --light-card: #ffffff;
-    --light-text: #2d3748;
-    --light-border: rgba(0, 0, 0, 0.08);
-    --shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
-    --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.05);
-    --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    --radius: 16px;
-    --radius-sm: 8px;
-    --skeleton-color: rgba(255, 255, 255, 0.1);
-    --skeleton-light: rgba(0, 0, 0, 0.05);
+  --primary-color: #3000ff;
+  --primary-hover: #2500cc;
+  --primary-light: rgba(48, 0, 255, 0.1);
+  --dark-bg: #0f0f13;
+  --dark-card: #1a1a23;
+  --dark-text: #f0f0f5;
+  --dark-border: rgba(255, 255, 255, 0.08);
+  --light-bg: #f8f9fa;
+  --light-card: #ffffff;
+  --light-text: #2d3748;
+  --light-border: rgba(0, 0, 0, 0.08);
+  --shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+  --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.05);
+  --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --radius: 16px;
+  --radius-sm: 8px;
+  --skeleton-color: rgba(255, 255, 255, 0.1);
+  --skeleton-light: rgba(0, 0, 0, 0.05);
 }
 
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 body {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', sans-serif;
-    background-color: var(--dark-bg);
-    color: var(--dark-text);
-    min-height: 100vh;
-    transition: var(--transition);
-    line-height: 1.6;
-    -webkit-font-smoothing: antialiased;
+  font-family:
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    "Open Sans",
+    sans-serif;
+  background-color: var(--dark-bg);
+  color: var(--dark-text);
+  min-height: 100vh;
+  transition: var(--transition);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
 }
 
 body.light-mode {
-    background-color: var(--light-bg);
-    color: var(--light-text);
+  background-color: var(--light-bg);
+  color: var(--light-text);
 }
 
 .auth-container {
-    display: none;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100vh;
-    padding: 20px;
-    text-align: center;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.3s ease, visibility 0s 0.3s;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  padding: 20px;
+  text-align: center;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 0.3s ease,
+    visibility 0s 0.3s;
 }
 
 .auth-container.active {
-    display: flex;
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.3s ease, visibility 0s;
+  display: flex;
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity 0.3s ease,
+    visibility 0s;
 }
 
 .auth-card {
-    background-color: var(--dark-card);
-    border-radius: var(--radius);
-    padding: 40px;
-    max-width: 500px;
-    width: 100%;
-    box-shadow: var(--shadow);
-    border: 1px solid var(--dark-border);
+  background-color: var(--dark-card);
+  border-radius: var(--radius);
+  padding: 40px;
+  max-width: 500px;
+  width: 100%;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--dark-border);
 }
 
 .light-mode .auth-card {
-    background-color: var(--light-card);
-    border: 1px solid var(--light-border);
+  background-color: var(--light-card);
+  border: 1px solid var(--light-border);
 }
 
 .auth-title {
-    font-size: 1.8rem;
-    font-weight: 700;
-    margin-bottom: 20px;
-    color: var(--primary-color);
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 20px;
+  color: var(--primary-color);
 }
 
 .auth-message {
-    margin-bottom: 30px;
-    color: var(--dark-text);
-    opacity: 0.8;
+  margin-bottom: 30px;
+  color: var(--dark-text);
+  opacity: 0.8;
 }
 
 .light-mode .auth-message {
-    color: var(--light-text);
+  color: var(--light-text);
 }
 
 .auth-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
 }
 
 .auth-btn {
-    padding: 14px 20px;
-    border-radius: var(--radius-sm);
-    font-weight: 600;
-    text-decoration: none;
-    text-align: center;
-    transition: var(--transition);
+  padding: 14px 20px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  text-decoration: none;
+  text-align: center;
+  transition: var(--transition);
 }
 
 .auth-btn-primary {
-    background-color: var(--primary-color);
-    color: white;
+  background-color: var(--primary-color);
+  color: white;
 }
 
 .auth-btn-primary:hover {
-    background-color: var(--primary-hover);
-    transform: translateY(-2px);
+  background-color: var(--primary-hover);
+  transform: translateY(-2px);
 }
 
 .auth-btn-secondary {
-    background-color: rgba(255, 255, 255, 0.05);
-    color: var(--dark-text);
-    border: 1px solid var(--dark-border);
+  background-color: rgba(255, 255, 255, 0.05);
+  color: var(--dark-text);
+  border: 1px solid var(--dark-border);
 }
 
 .light-mode .auth-btn-secondary {
-    background-color: rgba(0, 0, 0, 0.05);
-    color: var(--light-text);
-    border: 1px solid var(--light-border);
+  background-color: rgba(0, 0, 0, 0.05);
+  color: var(--light-text);
+  border: 1px solid var(--light-border);
 }
 
 .auth-btn-secondary:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 .light-mode .auth-btn-secondary:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 .success-modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.7);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
-    opacity: 0;
-    visibility: hidden;
-    transition: var(--transition);
-    backdrop-filter: blur(5px);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  transition: var(--transition);
+  backdrop-filter: blur(5px);
 }
 
 .success-modal.active {
-    opacity: 1;
-    visibility: visible;
+  opacity: 1;
+  visibility: visible;
 }
 
 .success-modal-content {
-    background-color: var(--dark-card);
-    border-radius: var(--radius);
-    width: 90%;
-    max-width: 500px;
-    padding: 30px;
-    box-shadow: var(--shadow);
-    transform: translateY(20px);
-    transition: var(--transition);
-    border: 1px solid var(--dark-border);
-    text-align: center;
+  background-color: var(--dark-card);
+  border-radius: var(--radius);
+  width: 90%;
+  max-width: 500px;
+  padding: 30px;
+  box-shadow: var(--shadow);
+  transform: translateY(20px);
+  transition: var(--transition);
+  border: 1px solid var(--dark-border);
+  text-align: center;
 }
 
 .light-mode .success-modal-content {
-    background-color: var(--light-card);
-    border: 1px solid var(--light-border);
+  background-color: var(--light-card);
+  border: 1px solid var(--light-border);
 }
 
 .success-modal.active .success-modal-content {
-    transform: translateY(0);
+  transform: translateY(0);
 }
 
 .success-icon {
-    width: 80px;
-    height: 80px;
-    margin: 0 auto 20px;
-    display: block;
+  width: 80px;
+  height: 80px;
+  margin: 0 auto 20px;
+  display: block;
 }
 
 .success-title {
-    font-size: 1.5rem;
-    font-weight: 700;
-    margin-bottom: 15px;
-    color: var(--primary-color);
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 15px;
+  color: var(--primary-color);
 }
 
 .success-message {
-    margin-bottom: 25px;
-    color: var(--dark-text);
+  margin-bottom: 25px;
+  color: var(--dark-text);
 }
 
 .light-mode .success-message {
-    color: var(--light-text);
+  color: var(--light-text);
 }
 
 .success-btn {
-    padding: 12px 24px;
-    border-radius: var(--radius-sm);
-    font-weight: 600;
-    background-color: var(--primary-color);
-    color: white;
-    border: none;
-    cursor: pointer;
-    transition: var(--transition);
+  padding: 12px 24px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  cursor: pointer;
+  transition: var(--transition);
 }
 
 .success-btn:hover {
-    background-color: var(--primary-hover);
-    transform: translateY(-2px);
+  background-color: var(--primary-hover);
+  transform: translateY(-2px);
 }
 
 header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 16px 5%;
-    background-color: var(--dark-card);
-    box-shadow: var(--shadow-sm);
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    transition: var(--transition);
-    border-bottom: 1px solid var(--dark-border);
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.3s ease, visibility 0s 0.3s;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 5%;
+  background-color: var(--dark-card);
+  box-shadow: var(--shadow-sm);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  transition: var(--transition);
+  border-bottom: 1px solid var(--dark-border);
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 0.3s ease,
+    visibility 0s 0.3s;
 }
 
 header.active {
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.3s ease, visibility 0s;
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity 0.3s ease,
+    visibility 0s;
 }
 
 .light-mode header {
-    background-color: var(--light-card);
-    border-bottom: 1px solid var(--light-border);
+  background-color: var(--light-card);
+  border-bottom: 1px solid var(--light-border);
 }
 
 .logo-link {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    text-decoration: none;
-    padding: 8px 16px;
-    border-radius: 12px;
-    color: var(--dark-text);
-    transition: var(--transition);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  padding: 8px 16px;
+  border-radius: 12px;
+  color: var(--dark-text);
+  transition: var(--transition);
 }
 
 .light-mode .logo-link {
-    color: var(--light-text);
+  color: var(--light-text);
 }
 
 .logo-link:hover {
-    background-color: var(--primary-light);
+  background-color: var(--primary-light);
 }
 
 .logo {
-    width: 32px;
-    height: 32px;
-    object-fit: contain;
-    transition: var(--transition);
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  transition: var(--transition);
 }
 
 .site-title {
-    font-size: 1.2rem;
-    font-weight: 700;
-    letter-spacing: 0.5px;
-    transition: var(--transition);
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  transition: var(--transition);
 }
 
 .theme-switcher {
-    background: none;
-    border: none;
-    cursor: pointer;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: var(--transition);
-    background-color: rgba(255, 255, 255, 0.05);
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition);
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 .theme-switcher:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-    transform: rotate(15deg);
+  background-color: rgba(255, 255, 255, 0.1);
+  transform: rotate(15deg);
 }
 
 .light-mode .theme-switcher {
-    background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .light-mode .theme-switcher:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 .theme-icon {
-    width: 20px;
-    height: 20px;
-    transition: var(--transition);
+  width: 20px;
+  height: 20px;
+  transition: var(--transition);
 }
 
 .container {
-    display: flex;
-    width: 100%;
-    max-width: 1200px;
-    margin: 30px auto;
-    padding: 0 5%;
-    gap: 25px;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.3s ease, visibility 0s 0.3s;
+  display: flex;
+  width: 100%;
+  max-width: 1200px;
+  margin: 30px auto;
+  padding: 0 5%;
+  gap: 25px;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 0.3s ease,
+    visibility 0s 0.3s;
 }
 
 .main-content-container {
-    display: none;
+  display: none;
 }
 
 .main-content-container.active {
-    display: block;
+  display: block;
 }
 
 .container.active {
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.3s ease, visibility 0s;
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity 0.3s ease,
+    visibility 0s;
 }
 
 .sidebar {
-    width: 280px;
-    background-color: var(--dark-card);
-    border-radius: var(--radius);
-    padding: 16px 0 0px;
-    box-shadow: var(--shadow);
-    transition: var(--transition);
-    height: fit-content;
-    border: 1px solid var(--dark-border);
+  width: 280px;
+  background-color: var(--dark-card);
+  border-radius: var(--radius);
+  padding: 16px 0 0px;
+  box-shadow: var(--shadow);
+  transition: var(--transition);
+  height: fit-content;
+  border: 1px solid var(--dark-border);
 }
 
 .light-mode .sidebar {
-    background-color: var(--light-card);
-    border: 1px solid var(--light-border);
+  background-color: var(--light-card);
+  border: 1px solid var(--light-border);
 }
 
 .sidebar-header {
-    padding: 0 20px 16px;
-    border-bottom: 1px solid var(--dark-border);
-    margin-bottom: 16px;
+  padding: 0 20px 16px;
+  border-bottom: 1px solid var(--dark-border);
+  margin-bottom: 16px;
 }
 
 .light-mode .sidebar-header {
-    border-bottom: 1px solid var(--light-border);
+  border-bottom: 1px solid var(--light-border);
 }
 
 .sidebar-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--dark-text);
-    letter-spacing: 0.5px;
-    text-transform: uppercase;
-    opacity: 0.7;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--dark-text);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  opacity: 0.7;
 }
 
 .light-mode .sidebar-title {
-    color: var(--light-text);
+  color: var(--light-text);
 }
 
 .sidebar-menu {
-    list-style: none;
+  list-style: none;
 }
 
 .sidebar-menu li {
-    margin-bottom: 4px;
+  margin-bottom: 4px;
 }
 
 .sidebar-menu a {
-    display: flex;
-    align-items: center;
-    padding: 12px 20px;
-    color: var(--dark-text);
-    text-decoration: none;
-    font-weight: 500;
-    border-radius: var(--radius-sm);
-    transition: var(--transition);
-    position: relative;
-    font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  padding: 12px 20px;
+  color: var(--dark-text);
+  text-decoration: none;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  transition: var(--transition);
+  position: relative;
+  font-size: 0.95rem;
 }
 
 .light-mode .sidebar-menu a {
-    color: var(--light-text);
+  color: var(--light-text);
 }
 
 .sidebar-menu a:hover {
-    background-color: var(--primary-light);
-    transform: translateX(4px);
+  background-color: var(--primary-light);
+  transform: translateX(4px);
 }
 
 .sidebar-menu a.active {
-    background-color: rgba(48, 0, 255, 0.5);
-    color: rgb(47, 0, 255);
-    font-weight: 600;
+  background-color: rgba(48, 0, 255, 0.5);
+  color: rgb(47, 0, 255);
+  font-weight: 600;
 }
 
 .sidebar-menu a::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
-    width: 3px;
-    background-color: var(--primary-color);
-    border-radius: 0 3px 3px 0;
-    opacity: 0;
-    transition: var(--transition);
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 3px;
+  background-color: var(--primary-color);
+  border-radius: 0 3px 3px 0;
+  opacity: 0;
+  transition: var(--transition);
 }
 
 .sidebar-menu a:hover::before {
-    opacity: 1;
+  opacity: 1;
 }
 
 .sidebar-menu a.active::before {
-    opacity: 1;
-    background-color: rgb(47, 0, 255);
+  opacity: 1;
+  background-color: rgb(47, 0, 255);
 }
 
 .sidebar-menu a[href*="logout"] {
-    color: #ff0000;
-    font-weight: 600;
-    transition: var(--transition);
+  color: #ff0000;
+  font-weight: 600;
+  transition: var(--transition);
 }
 
 .sidebar-menu a[href*="logout"]:hover {
-    background-color: rgba(255, 77, 77, 0.1);
-    transform: translateX(4px);
+  background-color: rgba(255, 77, 77, 0.1);
+  transform: translateX(4px);
 }
 
 .sidebar-menu a[href*="logout"]::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
-    width: 3px;
-    background-color: #ff0000;
-    border-radius: 0 3px 3px 0;
-    opacity: 0;
-    transition: var(--transition);
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 3px;
+  background-color: #ff0000;
+  border-radius: 0 3px 3px 0;
+  opacity: 0;
+  transition: var(--transition);
 }
 
 .sidebar-menu a[href*="logout"]:hover::before {
-    opacity: 1;
+  opacity: 1;
 }
 
 .sidebar-icon {
-    width: 18px;
-    height: 18px;
-    margin-right: 12px;
-    opacity: 0.8;
-    transition: var(--transition);
+  width: 18px;
+  height: 18px;
+  margin-right: 12px;
+  opacity: 0.8;
+  transition: var(--transition);
 }
 
 .sidebar-menu a.active .sidebar-icon {
-    opacity: 1;
+  opacity: 1;
 }
 
 .main-content {
-    flex-grow: 1;
-    background-color: var(--dark-card);
-    border-radius: var(--radius);
-    padding: 30px;
-    box-shadow: var(--shadow);
-    transition: var(--transition);
-    border: 1px solid var(--dark-border);
+  flex-grow: 1;
+  background-color: var(--dark-card);
+  border-radius: var(--radius);
+  padding: 30px;
+  box-shadow: var(--shadow);
+  transition: var(--transition);
+  border: 1px solid var(--dark-border);
 }
 
 .light-mode .main-content {
-    background-color: var(--light-card);
-    border: 1px solid var(--light-border);
+  background-color: var(--light-card);
+  border: 1px solid var(--light-border);
 }
 
 .profile-header {
-    text-align: center;
-    margin-bottom: 30px;
+  text-align: center;
+  margin-bottom: 30px;
 }
 
 .profile-title {
-    font-size: 1.8rem;
-    font-weight: 700;
-    margin-bottom: 8px;
-    color: var(--dark-text);
-    background: linear-gradient(90deg, var(--primary-color), #6a00ff);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    display: inline-block;
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: var(--dark-text);
+  background: linear-gradient(90deg, var(--primary-color), #6a00ff);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  display: inline-block;
 }
 
 .light-mode .profile-title {
-    background: linear-gradient(90deg, var(--primary-color), #6a00ff);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+  background: linear-gradient(90deg, var(--primary-color), #6a00ff);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .profile-subtitle {
-    color: #aaa;
-    font-size: 1rem;
-    max-width: 500px;
-    margin: 0 auto;
-    line-height: 1.5;
+  color: #aaa;
+  font-size: 1rem;
+  max-width: 500px;
+  margin: 0 auto;
+  line-height: 1.5;
 }
 
 .profile-card {
-    background: linear-gradient(135deg, rgba(48, 0, 255, 0.1) 0%, rgba(48, 0, 255, 0.05) 100%);
-    border-radius: var(--radius);
-    padding: 30px;
-    margin-bottom: 30px;
-    border: 1px solid rgba(48, 0, 255, 0.2);
-    transition: var(--transition);
-    backdrop-filter: blur(10px);
+  background: linear-gradient(
+    135deg,
+    rgba(48, 0, 255, 0.1) 0%,
+    rgba(48, 0, 255, 0.05) 100%
+  );
+  border-radius: var(--radius);
+  padding: 30px;
+  margin-bottom: 30px;
+  border: 1px solid rgba(48, 0, 255, 0.2);
+  transition: var(--transition);
+  backdrop-filter: blur(10px);
 }
 
 .light-mode .profile-card {
-    background: linear-gradient(135deg, rgba(48, 0, 255, 0.05) 0%, rgba(48, 0, 255, 0.02) 100%);
-    border: 1px solid rgba(48, 0, 255, 0.1);
+  background: linear-gradient(
+    135deg,
+    rgba(48, 0, 255, 0.05) 0%,
+    rgba(48, 0, 255, 0.02) 100%
+  );
+  border: 1px solid rgba(48, 0, 255, 0.1);
 }
 
 .profile-info {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
 }
 
 .avatar-container {
-    position: relative;
-    width: 120px;
-    height: 120px;
-    margin-bottom: 10px;
+  position: relative;
+  width: 120px;
+  height: 120px;
+  margin-bottom: 10px;
 }
 
 .avatar {
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-    object-fit: cover;
-    border: 3px solid var(--primary-color);
-    transition: var(--transition);
-    cursor: pointer;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
-    opacity: 0;
-    transition: opacity 0.3s ease;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid var(--primary-color);
+  transition: var(--transition);
+  cursor: pointer;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .avatar.active {
-    opacity: 1;
+  opacity: 1;
 }
 
 .avatar:hover {
-    transform: scale(1.05);
-    box-shadow: 0 0 30px rgba(48, 0, 255, 0.4);
+  transform: scale(1.05);
+  box-shadow: 0 0 30px rgba(48, 0, 255, 0.4);
 }
 
 .avatar-edit {
-    position: absolute;
-    bottom: 5px;
-    right: 5px;
-    background-color: var(--primary-color);
-    width: 36px;
-    height: 36px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: var(--transition);
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  background-color: var(--primary-color);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: var(--transition);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
 }
 
 .avatar-edit:hover {
-    background-color: var(--primary-hover);
-    transform: scale(1.1) rotate(10deg);
+  background-color: var(--primary-hover);
+  transform: scale(1.1) rotate(10deg);
 }
 
 .avatar-edit-icon {
-    width: 16px;
-    height: 16px;
-    filter: brightness(0) invert(1);
+  width: 16px;
+  height: 16px;
+  filter: brightness(0) invert(1);
 }
 
 .username-container {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 auto;
 }
 
-.letter{
-    display:inline-block;
-    opacity:0;
-    filter:blur(0px);
-    transform:translateY(-10px);
-    animation:pop .2s forwards;
-    animation-delay:calc(var(--i)*15ms)
+.letter {
+  display: inline-block;
+  opacity: 0;
+  filter: blur(0px);
+  transform: translateY(-10px);
+  animation: pop 0.2s forwards;
+  animation-delay: calc(var(--i) * 15ms);
 }
 
-@keyframes pop{
-    to{
-        opacity:1;
-        filter:blur(0);
-        transform:translateY(0)
-    }
+@keyframes pop {
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
 }
 
 .username {
-    font-size: 1.8rem;
-    font-weight: 700;
-    color: var(--dark-text);
-    letter-spacing: -0.5px;
-    opacity: 0;
-    transition: opacity 0.3s ease;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--dark-text);
+  letter-spacing: -0.5px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .username.active {
-    opacity: 1;
+  opacity: 1;
 }
 
 .light-mode .username {
-    color: var(--light-text);
+  color: var(--light-text);
 }
 
 .verified-badge {
-    width: 20px;
-    height: 20px;
-    opacity: 0;
-    transition: opacity 0.3s ease;
+  width: 20px;
+  height: 20px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .verified-badge.active {
-    opacity: 1;
-    margin-top: 5px;
-    margin-left: 5px;
-    animation: fadeIn 0.3s ease, scaleUp 0.3s ease;
-    transform: translateX(-5px);
+  opacity: 1;
+  margin-top: 5px;
+  margin-left: 5px;
+  animation:
+    fadeIn 0.3s ease,
+    scaleUp 0.3s ease;
+  transform: translateX(-5px);
 }
 
 @keyframes scaleUp {
-    from {
+  from {
     transform: scale(0.9) translateX(0);
-    }
-    to {
+  }
+  to {
     transform: scale(1) translateX(-5px);
-    }
+  }
 }
 
 .member-date {
-    display: none;
-    color: #aaa;
-    font-size: 0.95rem;
-    margin-bottom: 15px;
-    opacity: 0;
-    transition: opacity 0.3s ease;
+  display: none;
+  color: #aaa;
+  font-size: 0.95rem;
+  margin-bottom: 15px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .member-date.active {
-    display: flex;
-    opacity: 0.8;
+  display: flex;
+  opacity: 0.8;
 }
 
 .email-container {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    background-color: rgba(255, 255, 255, 0.05);
-    padding: 12px 20px;
-    border-radius: 50px;
-    transition: var(--transition);
-    border: 1px solid var(--dark-border);
-    position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background-color: rgba(255, 255, 255, 0.05);
+  padding: 12px 20px;
+  border-radius: 50px;
+  transition: var(--transition);
+  border: 1px solid var(--dark-border);
+  position: relative;
 }
 
 .light-mode .email-container {
-    background-color: rgba(0, 0, 0, 0.05);
-    border: 1px solid var(--light-border);
+  background-color: rgba(0, 0, 0, 0.05);
+  border: 1px solid var(--light-border);
 }
 
 .email {
-    display: none;
-    font-size: 0.95rem;
-    font-weight: 500;
-    font-family: 'Roboto Mono', monospace;
-    opacity: 0;
-    transition: opacity 0.3s ease;
+  display: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  font-family: "Roboto Mono", monospace;
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .email.active {
-    display: flex;
-    opacity: 1;
+  display: flex;
+  opacity: 1;
 }
 
 .email-toggle {
-    display: none;
-    width: 20px;
-    height: 20px;
-    cursor: pointer;
-    transition: var(--transition);
-    opacity: 0;
-    transition: opacity 0.3s ease;
+  display: none;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  transition: var(--transition);
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .email-toggle.active {
-    display: flex;
-    opacity: 0.7;
+  display: flex;
+  opacity: 0.7;
 }
 
 .email-toggle:hover {
-    opacity: 1;
-    transform: scale(1.1);
+  opacity: 1;
+  transform: scale(1.1);
 }
 
 .email-edit {
-    display: none;
-    width: 20px;
-    height: 20px;
-    cursor: pointer;
-    transition: var(--transition);
-    opacity: 0;
-    transition: opacity 0.3s ease;
-    margin-left: 8px;
+  display: none;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  transition: var(--transition);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  margin-left: 8px;
 }
 
 .email-edit.active {
-    display: flex;
-    opacity: 0.7;
+  display: flex;
+  opacity: 0.7;
 }
 
 .email-edit:hover {
-    opacity: 1;
-    transform: scale(1.1);
+  opacity: 1;
+  transform: scale(1.1);
 }
 
 .stats-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 16px;
-    margin-top: 30px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-top: 30px;
 }
 
 .stat-card {
-    background-color: rgba(255, 255, 255, 0.05);
-    border-radius: var(--radius);
-    padding: 25px;
-    text-align: center;
-    transition: var(--transition);
-    border: 1px solid var(--dark-border);
-    position: relative;
-    overflow: hidden;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius);
+  padding: 25px;
+  text-align: center;
+  transition: var(--transition);
+  border: 1px solid var(--dark-border);
+  position: relative;
+  overflow: hidden;
 }
 
 .light-mode .stat-card {
-    background-color: rgba(0, 0, 0, 0.05);
-    border: 1px solid var(--light-border);
+  background-color: rgba(0, 0, 0, 0.05);
+  border: 1px solid var(--light-border);
 }
 
 .stat-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
-    border-color: var(--primary-color);
+  transform: translateY(-5px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  border-color: var(--primary-color);
 }
 
 .stat-card::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 3px;
-    height: 100%;
-    background-color: var(--primary-color);
-    opacity: 0;
-    transition: var(--transition);
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3px;
+  height: 100%;
+  background-color: var(--primary-color);
+  opacity: 0;
+  transition: var(--transition);
 }
 
 .stat-card:hover::before {
-    opacity: 1;
+  opacity: 1;
 }
 
 .stat-value {
-    font-size: 2.2rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin-bottom: 5px;
-    font-feature-settings: "tnum";
-    font-variant-numeric: tabular-nums;
-    opacity: 0;
-    transition: opacity 0.3s ease;
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: var(--primary-color);
+  margin-bottom: 5px;
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .stat-value.active {
-    opacity: 1;
+  opacity: 1;
 }
 
 .stat-label {
-    font-size: 0.9rem;
-    color: #aaa;
-    letter-spacing: 0.5px;
-    text-transform: uppercase;
-    opacity: 0;
-    transition: opacity 0.3s ease;
+  font-size: 0.9rem;
+  color: #aaa;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .stat-label.active {
-    opacity: 0.8;
+  opacity: 0.8;
 }
 
 .skeleton {
-    background-color: var(--skeleton-color);
-    border-radius: 4px;
-    position: relative;
-    overflow: hidden;
-    opacity: 1;
-    transition: opacity 0.3s ease;
+  background-color: var(--skeleton-color);
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+  opacity: 1;
+  transition: opacity 0.3s ease;
 }
 
 .skeleton.fade-out {
-    opacity: 0;
-    pointer-events: none;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .skeleton.hidden {
-    opacity: 0;
-    pointer-events: none;
-    display: none;
+  opacity: 0;
+  pointer-events: none;
+  display: none;
 }
 
 .light-mode .skeleton {
-    background-color: var(--skeleton-light);
+  background-color: var(--skeleton-light);
 }
 
 .skeleton::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.05), transparent);
-    animation: shimmer 1.5s infinite;
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.05),
+    transparent
+  );
+  animation: shimmer 1.5s infinite;
 }
 
 .light-mode .skeleton::after {
-    background: linear-gradient(90deg, transparent, rgba(0, 0, 0, 0.05), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(0, 0, 0, 0.05),
+    transparent
+  );
 }
 
 .skeleton-avatar {
-    width: 120px;
-    height: 120px;
-    border-radius: 50%;
-    margin-bottom: 10px;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  margin-bottom: 10px;
 }
 
 .skeleton-username {
-    margin-left: 200px !important;
-    width: 180px;
-    height: 32px;
-    margin: 10px 0;
+  margin-left: 200px !important;
+  width: 180px;
+  height: 32px;
+  margin: 10px 0;
 }
 
 .skeleton-date {
-    width: 150px;
-    height: 16px;
-    margin-bottom: 15px;
+  width: 150px;
+  height: 16px;
+  margin-bottom: 15px;
 }
 
 .skeleton-email {
-    width: 200px !important;
-    height: 20px;
-    margin: 0 auto;
+  width: 200px !important;
+  height: 20px;
+  margin: 0 auto;
 }
 
 .skeleton-stat {
-    width: 60px;
-    height: 40px;
-    margin: 0 auto 8px;
+  width: 60px;
+  height: 40px;
+  margin: 0 auto 8px;
 }
 
 .skeleton-label {
-    width: 100px;
-    height: 12px;
-    margin: 0 auto;
+  width: 100px;
+  height: 12px;
+  margin: 0 auto;
 }
 
 .skeleton-status-text {
-    width: 120px;
-    height: 24px;
-    border-radius: 4px;
+  width: 120px;
+  height: 24px;
+  border-radius: 4px;
 }
 
 .skeleton-status-desc {
-    width: 200px;
-    height: 16px;
-    border-radius: 4px;
-    margin-top: 8px;
+  width: 200px;
+  height: 16px;
+  border-radius: 4px;
+  margin-top: 8px;
 }
 
 .skeleton-status-bar {
-    width: 100%;
-    height: 18px;
-    border-radius: 10px;
-    margin-bottom: 10px;
+  width: 100%;
+  height: 18px;
+  border-radius: 10px;
+  margin-bottom: 10px;
 }
 
 .modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.7);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
-    opacity: 0;
-    visibility: hidden;
-    transition: var(--transition);
-    backdrop-filter: blur(5px);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  transition: var(--transition);
+  backdrop-filter: blur(5px);
 }
 
 .modal-overlay.active {
-    opacity: 1;
-    visibility: visible;
+  opacity: 1;
+  visibility: visible;
 }
 
 .modal {
-    background-color: var(--dark-card);
-    border-radius: var(--radius);
-    width: 90%;
-    max-width: 500px;
-    padding: 30px;
-    box-shadow: var(--shadow);
-    transform: translateY(20px);
-    transition: var(--transition);
-    border: 1px solid var(--dark-border);
+  background-color: var(--dark-card);
+  border-radius: var(--radius);
+  width: 90%;
+  max-width: 500px;
+  padding: 30px;
+  box-shadow: var(--shadow);
+  transform: translateY(20px);
+  transition: var(--transition);
+  border: 1px solid var(--dark-border);
 }
 
 .light-mode .modal {
-    background-color: var(--light-card);
-    border: 1px solid var(--light-border);
+  background-color: var(--light-card);
+  border: 1px solid var(--light-border);
 }
 
 .modal-overlay.active .modal {
-    transform: translateY(0);
+  transform: translateY(0);
 }
 
 .modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
 }
 
 .modal-title {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--dark-text);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--dark-text);
 }
 
 .light-mode .modal-title {
-    color: var(--light-text);
+  color: var(--light-text);
 }
 
 .modal-close {
-    background: none;
-    border: none;
-    cursor: pointer;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: var(--transition);
-    background-color: rgba(255, 255, 255, 0.05);
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition);
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 .light-mode .modal-close {
-    background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .modal-close:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 .light-mode .modal-close:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 .modal-close-icon {
-    width: 16px;
-    height: 16px;
+  width: 16px;
+  height: 16px;
 }
 
 .modal-body {
-    margin-bottom: 25px;
+  margin-bottom: 25px;
 }
 
 .form-group {
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .form-label {
-    display: block;
-    margin-bottom: 8px;
-    font-weight: 500;
-    color: var(--dark-text);
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+  color: var(--dark-text);
 }
 
 .light-mode .form-label {
-    color: var(--light-text);
+  color: var(--light-text);
 }
 
 .form-input {
-    width: 100%;
-    padding: 12px 16px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--dark-border);
-    background-color: rgba(255, 255, 255, 0.05);
-    color: var(--dark-text);
-    font-family: inherit;
-    font-size: 1rem;
-    transition: var(--transition);
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--dark-border);
+  background-color: rgba(255, 255, 255, 0.05);
+  color: var(--dark-text);
+  font-family: inherit;
+  font-size: 1rem;
+  transition: var(--transition);
 }
 
 .light-mode .form-input {
-    border: 1px solid var(--light-border);
-    background-color: rgba(0, 0, 0, 0.05);
-    color: var(--light-text);
+  border: 1px solid var(--light-border);
+  background-color: rgba(0, 0, 0, 0.05);
+  color: var(--light-text);
 }
 
 .form-input:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(48, 0, 255, 0.1);
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(48, 0, 255, 0.1);
 }
 
 .modal-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
 }
 
 .modal-footer .btn:disabled,
 .modal-close:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    pointer-events: none;
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .spinner {
-    border: 2px solid rgba(255,255,255,0.6);
-    border-top: 2px solid white;
-    border-radius: 50%;
-    width: 16px;
-    height: 16px;
-    animation: spin 0.6s linear infinite;
-    display: inline-block;
-    vertical-align: middle;
-    margin-right: 8px;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-top: 2px solid white;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  animation: spin 0.6s linear infinite;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 8px;
 }
 
 @keyframes spin {
-    to {
-        transform: rotate(360deg);
-    }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .btn {
-    padding: 10px 20px;
-    border-radius: var(--radius-sm);
-    font-weight: 500;
-    font-size: 0.95rem;
-    cursor: pointer;
-    transition: var(--transition);
-    border: none;
+  padding: 10px 20px;
+  border-radius: var(--radius-sm);
+  font-weight: 500;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: var(--transition);
+  border: none;
 }
 
 .btn-primary {
-    background-color: var(--primary-color);
-    color: white;
+  background-color: var(--primary-color);
+  color: white;
 }
 
 .btn-primary:hover {
-    background-color: var(--primary-hover);
-    transform: translateY(-2px);
+  background-color: var(--primary-hover);
+  transform: translateY(-2px);
 }
 
 .btn-secondary {
-    background-color: rgba(255, 255, 255, 0.05);
-    color: var(--dark-text);
+  background-color: rgba(255, 255, 255, 0.05);
+  color: var(--dark-text);
 }
 
 .light-mode .btn-secondary {
-    background-color: rgba(0, 0, 0, 0.05);
-    color: var(--light-text);
+  background-color: rgba(0, 0, 0, 0.05);
+  color: var(--light-text);
 }
 
 .btn-secondary:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 .light-mode .btn-secondary:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 .avatar-preview-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
 }
 
 .avatar-preview {
-    width: 180px;
-    height: 180px;
-    border-radius: 50%;
-    object-fit: cover;
-    border: 4px solid var(--primary-color);
-    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid var(--primary-color);
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
 }
 
 .hidden {
-    display: none;
+  display: none;
 }
 
 .error-message {
-    color: #ff4444;
-    background-color: rgba(255, 68, 68, 0.1);
-    padding: 12px;
-    border-radius: var(--radius-sm);
-    margin-bottom: 20px;
-    border: 1px solid rgba(255, 68, 68, 0.3);
-    display: flex;
-    align-items: center;
-    gap: 10px;
+  color: #ff4444;
+  background-color: rgba(255, 68, 68, 0.1);
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  margin-bottom: 20px;
+  border: 1px solid rgba(255, 68, 68, 0.3);
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .error-icon {
-    width: 20px;
-    height: 20px;
+  width: 20px;
+  height: 20px;
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-5px); }
-    to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes pulse {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.05); }
-    100% { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 @keyframes float {
-    0% { transform: translateY(0px); }
-    50% { transform: translateY(-5px); }
-    100% { transform: translateY(0px); }
+  0% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-5px);
+  }
+  100% {
+    transform: translateY(0px);
+  }
 }
 
 @keyframes shimmer {
-    0% { transform: translateX(-100%); }
-    100% { transform: translateX(100%); }
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 @media (max-width: 992px) {
-    .container {
-        flex-direction: column;
-    }
+  .container {
+    flex-direction: column;
+  }
 
-    .sidebar {
-        width: 100%;
-    }
+  .sidebar {
+    width: 100%;
+  }
 }
 
 @media (max-width: 768px) {
-    .profile-title {
-        font-size: 1.5rem;
-    }
-    
-    .username {
-        font-size: 1.5rem;
-    }
-    
-    .profile-card {
-        padding: 20px;
-    }
+  .profile-title {
+    font-size: 1.5rem;
+  }
+
+  .username {
+    font-size: 1.5rem;
+  }
+
+  .profile-card {
+    padding: 20px;
+  }
 }
 
 @media (max-width: 576px) {
-    .stats-container {
-        grid-template-columns: 1fr 1fr;
-    }
-    
-    .profile-header {
-        margin-bottom: 20px;
-    }
-    
-    .avatar-container {
-        width: 100px;
-        height: 100px;
-    }
-    
-    .username {
-        font-size: 1.3rem;
-    }
-    
-    .email-container {
-        padding: 10px 16px;
-    }
+  .stats-container {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .profile-header {
+    margin-bottom: 20px;
+  }
+
+  .avatar-container {
+    width: 100px;
+    height: 100px;
+  }
+
+  .username {
+    font-size: 1.3rem;
+  }
+
+  .email-container {
+    padding: 10px 16px;
+  }
 }
 
 @media (max-width: 400px) {
-    .stats-container {
-        grid-template-columns: 1fr;
-    }
-    
-    .stat-card {
-        padding: 20px;
-    }
+  .stats-container {
+    grid-template-columns: 1fr;
+  }
+
+  .stat-card {
+    padding: 20px;
+  }
 }
 
 .tabs-header {
-    display: flex;
-    border-bottom: 1px solid rgba(48,0,255,0.12);
-    background: transparent;
-    border-radius: var(--radius) var(--radius) 0 0;
-    overflow: hidden;
+  display: flex;
+  border-bottom: 1px solid rgba(48, 0, 255, 0.12);
+  background: transparent;
+  border-radius: var(--radius) var(--radius) 0 0;
+  overflow: hidden;
 }
 .tab-btn {
-    flex:1;
-    background: none;
-    border: none;
-    outline: none;
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: #888;
-    padding: 18px 0;
-    cursor: pointer;
-    transition: background 0.2s, color 0.2s;
-    border-bottom: 3px solid transparent;
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #888;
+  padding: 18px 0;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    color 0.2s;
+  border-bottom: 3px solid transparent;
 }
 .tab-btn:hover {
-    background: rgba(48,0,255,0.07);
-    color: var(--primary-color);
+  background: rgba(48, 0, 255, 0.07);
+  color: var(--primary-color);
 }
 .tab-btn.active {
-    background: rgba(48,0,255,0.10);
-    color: var(--primary-color);
-    border-bottom: 3px solid var(--primary-color);
+  background: rgba(48, 0, 255, 0.1);
+  color: var(--primary-color);
+  border-bottom: 3px solid var(--primary-color);
 }
-.tab-content { display:none;}
-.tab-content.active { display:block;}
+.tab-content {
+  display: none;
+}
+.tab-content.active {
+  display: block;
+}
 .status-progress-bar {
-    width: 100%;
-    background: #232333;
-    height: 18px;
-    border-radius: 10px;
-    margin-bottom: 10px;
-    position: relative;
-    overflow: hidden;
-    box-shadow: 0 2px 8px #0001;
-    border:1px solid rgba(48,0,255,0.12);
+  width: 100%;
+  background: #232333;
+  height: 18px;
+  border-radius: 10px;
+  margin-bottom: 10px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 2px 8px #0001;
+  border: 1px solid rgba(48, 0, 255, 0.12);
 }
 .status-progress {
-    height: 100%;
-    border-radius: 10px;
-    transition: width 0.6s cubic-bezier(.7,.3,.2,1), background 0.3s;
-    width: 10%;
-    background: linear-gradient(90deg, #10c95a 0%, #ffca29 70%, #e94434 100%);
-    box-shadow: 0 2px 10px #3000ff22;
+  height: 100%;
+  border-radius: 10px;
+  transition:
+    width 0.6s cubic-bezier(0.7, 0.3, 0.2, 1),
+    background 0.3s;
+  width: 10%;
+  background: linear-gradient(90deg, #10c95a 0%, #ffca29 70%, #e94434 100%);
+  box-shadow: 0 2px 10px #3000ff22;
 }
 .status-labels {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 3px;
-    font-size: .91rem;
-    color: #bbb;
-    opacity: .85;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 3px;
+  font-size: 0.91rem;
+  color: #bbb;
+  opacity: 0.85;
 }
 .status-labels span {
-    flex:1;text-align:center;
+  flex: 1;
+  text-align: center;
 }
 .username-edit {
-    opacity:.6;
-    transition:opacity .2s;
+  opacity: 0.6;
+  transition: opacity 0.2s;
 }
-.username-edit:hover { opacity:1;}
+.username-edit:hover {
+  opacity: 1;
+}
 
 .sanction-icon {
-    width: 20px;
-    height: 20px;
-    margin-right: 8px;
-    vertical-align: middle;
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+.sanction-additional-info {
+  margin-top: 20px;
+  padding: 15px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-sm);
 }

--- a/frontend/src/CSS/admin/index.css
+++ b/frontend/src/CSS/admin/index.css
@@ -1,1145 +1,1172 @@
 :root {
-    --primary-color: #6366f1;
-    --primary-light: rgba(99, 102, 241, 0.1);
-    --text-color: #fff;
-    --bg-color: #0f172a;
-    --card-bg: rgba(30, 41, 59, 0.7);
-    --border-color: rgba(255, 255, 255, 0.1);
-    --success-color: #10b981;
-    --error-color: #ef4444;
-    --warning-color: #f59e0b;
-    --info-color: #3b82f6;
-    --skeleton-color: rgba(255, 255, 255, 0.05);
-    --clear-btn-padding: 10px 15px;
+  --primary-color: #6366f1;
+  --primary-light: rgba(99, 102, 241, 0.1);
+  --text-color: #fff;
+  --bg-color: #0f172a;
+  --card-bg: rgba(30, 41, 59, 0.7);
+  --border-color: rgba(255, 255, 255, 0.1);
+  --success-color: #10b981;
+  --error-color: #ef4444;
+  --warning-color: #f59e0b;
+  --info-color: #3b82f6;
+  --skeleton-color: rgba(255, 255, 255, 0.05);
+  --clear-btn-padding: 10px 15px;
 }
 
 .light-theme {
-    --text-color: #1e293b;
-    --bg-color: #f8fafc;
-    --card-bg: rgba(255, 255, 255, 0.9);
-    --border-color: rgba(0, 0, 0, 0.1);
-    --primary-light: rgba(99, 102, 241, 0.05);
-    --skeleton-color: rgba(0, 0, 0, 0.05);
+  --text-color: #1e293b;
+  --bg-color: #f8fafc;
+  --card-bg: rgba(255, 255, 255, 0.9);
+  --border-color: rgba(0, 0, 0, 0.1);
+  --primary-light: rgba(99, 102, 241, 0.05);
+  --skeleton-color: rgba(0, 0, 0, 0.05);
 }
 
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    font-family: 'Poppins', sans-serif;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: "Poppins", sans-serif;
 }
 
 body {
-    background-color: var(--bg-color);
-    color: var(--text-color);
-    transition: background-color 0.3s ease, color 0.3s ease;
-    min-height: 100vh;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
+  min-height: 100vh;
 }
 
 #preloader {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: var(--bg-color);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    z-index: 9999;
-    transition: opacity 0.5s ease;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--bg-color);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  transition: opacity 0.5s ease;
 }
 
 .spinner {
-    width: 50px;
-    height: 50px;
-    border: 3px solid var(--primary-color);
-    border-radius: 50%;
-    border-top-color: transparent;
-    animation: spin 1s linear infinite;
-    margin-bottom: 20px;
+  width: 50px;
+  height: 50px;
+  border: 3px solid var(--primary-color);
+  border-radius: 50%;
+  border-top-color: transparent;
+  animation: spin 1s linear infinite;
+  margin-bottom: 20px;
 }
 
 .spinner-btn {
-    width: var(--spinner-btn-size, 16px);
-    height: var(--spinner-btn-size, 16px);
-    border-width: 2px;
-    margin: 0 6px 0 0;
-    color: inherit;
-    border-color: currentColor;
-    border-top-color: transparent;
+  width: var(--spinner-btn-size, 16px);
+  height: var(--spinner-btn-size, 16px);
+  border-width: 2px;
+  margin: 0 6px 0 0;
+  color: inherit;
+  border-color: currentColor;
+  border-top-color: transparent;
 }
 
 @keyframes spin {
-    to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 #preloader-message {
-    font-size: 16px;
-    color: var(--text-color);
-    opacity: 0.8;
+  font-size: 16px;
+  color: var(--text-color);
+  opacity: 0.8;
 }
 
 .admin-header {
-    background: rgba(15, 23, 42, 0.8);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    padding: 15px 30px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 1px solid var(--border-color);
-    position: fixed;
-    width: 100%;
-    top: 0;
-    z-index: 1000;
+  background: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  padding: 15px 30px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+  position: fixed;
+  width: 100%;
+  top: 0;
+  z-index: 1000;
 }
 
 .light-theme .admin-header {
-    background: rgba(248, 250, 252, 0.8);
+  background: rgba(248, 250, 252, 0.8);
 }
 
 .admin-header h1 {
-    font-size: 24px;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 10px;
+  font-size: 24px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .admin-header span {
-    color: var(--primary-color);
+  color: var(--primary-color);
 }
 
 .logo {
-    width: 30px;
-    height: 30px;
+  width: 30px;
+  height: 30px;
 }
 
 .admin-nav {
-    display: flex;
-    align-items: center;
-    gap: 20px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
 }
 
 .admin-nav a {
-    color: var(--text-color);
-    text-decoration: none;
-    font-weight: 500;
-    padding: 8px 15px;
-    border-radius: 20px;
-    transition: all 0.3s ease;
-    display: flex;
-    align-items: center;
-    gap: 8px;
+  color: var(--text-color);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 8px 15px;
+  border-radius: 20px;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .admin-nav a:hover {
-    background-color: var(--primary-light);
+  background-color: var(--primary-light);
 }
 
 .admin-nav a.active {
-    background-color: var(--primary-color);
-    color: white;
+  background-color: var(--primary-color);
+  color: white;
 }
 
 .user-avatar {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    object-fit: cover;
-    cursor: pointer;
-    border: 2px solid var(--primary-color);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  cursor: pointer;
+  border: 2px solid var(--primary-color);
 }
 
 .theme-toggle {
-    background: none;
-    border: none;
-    color: var(--text-color);
-    font-size: 20px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    transition: background-color 0.3s ease;
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: 20px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  transition: background-color 0.3s ease;
 }
 
 .theme-toggle:hover {
-    background-color: var(--primary-light);
+  background-color: var(--primary-light);
 }
 
 .admin-sidebar {
-    width: 280px;
-    background: rgba(15, 23, 42, 0.8);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    height: calc(100vh - 70px);
-    position: fixed;
-    top: 70px;
-    left: 0;
-    padding: 20px 0;
-    border-right: 1px solid var(--border-color);
-    transition: all 0.3s ease;
-    z-index: 900;
-    display: flex;
-    flex-direction: column;
+  width: 280px;
+  background: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  height: calc(100vh - 70px);
+  position: fixed;
+  top: 70px;
+  left: 0;
+  padding: 20px 0;
+  border-right: 1px solid var(--border-color);
+  transition: all 0.3s ease;
+  z-index: 900;
+  display: flex;
+  flex-direction: column;
 }
 
 .light-theme .admin-sidebar {
-    background: rgba(248, 250, 252, 0.9);
+  background: rgba(248, 250, 252, 0.9);
 }
 
 .sidebar-item {
-    padding: 12px 25px;
-    display: flex;
-    align-items: center;
-    gap: 15px;
-    color: var(--text-color);
-    text-decoration: none;
-    transition: all 0.3s ease;
-    cursor: pointer;
-    font-size: 15px;
+  padding: 12px 25px;
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  color: var(--text-color);
+  text-decoration: none;
+  transition: all 0.3s ease;
+  cursor: pointer;
+  font-size: 15px;
 }
 
 .sidebar-item:hover {
-    background-color: var(--primary-light);
+  background-color: var(--primary-light);
 }
 
 .sidebar-item.active {
-    background-color: var(--primary-color);
-    color: white;
+  background-color: var(--primary-color);
+  color: white;
 }
 
 .sidebar-item i {
-    font-size: 18px;
-    width: 24px;
-    text-align: center;
+  font-size: 18px;
+  width: 24px;
+  text-align: center;
 }
 
 .sidebar-footer {
-    margin-top: auto;
-    padding: 20px;
-    border-top: 1px solid var(--border-color);
+  margin-top: auto;
+  padding: 20px;
+  border-top: 1px solid var(--border-color);
 }
 
 .sidebar-footer .sidebar-item {
-    padding: 10px 15px;
+  padding: 10px 15px;
 }
 
 .admin-content {
-    margin-left: 280px;
-    margin-top: 70px;
-    padding: 30px;
-    transition: margin-left 0.3s ease;
+  margin-left: 280px;
+  margin-top: 70px;
+  padding: 30px;
+  transition: margin-left 0.3s ease;
 }
 
 .section-title {
-    font-size: 28px;
-    margin-bottom: 25px;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 10px;
+  font-size: 28px;
+  margin-bottom: 25px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .section-title span {
-    color: var(--primary-color);
+  color: var(--primary-color);
 }
 
 .section-title i {
-    font-size: 24px;
+  font-size: 24px;
 }
 
 .stats-cards {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 20px;
-    margin-bottom: 30px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin-bottom: 30px;
 }
 
 .stat-card {
-    background: var(--card-bg);
-    border-radius: 12px;
-    padding: 20px;
-    backdrop-filter: blur(5px);
-    -webkit-backdrop-filter: blur(5px);
-    border: 1px solid var(--border-color);
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 20px;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid var(--border-color);
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .stat-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
+  transform: translateY(-5px);
+  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
 }
 
 .stat-card h3 {
-    font-size: 14px;
-    color: #94a3b8;
-    margin-bottom: 10px;
-    font-weight: 500;
-    display: flex;
-    align-items: center;
-    gap: 8px;
+  font-size: 14px;
+  color: #94a3b8;
+  margin-bottom: 10px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .stat-card .value {
-    font-size: 28px;
-    font-weight: 600;
-    margin-bottom: 5px;
+  font-size: 28px;
+  font-weight: 600;
+  margin-bottom: 5px;
 }
 
 .stat-card .change {
-    font-size: 13px;
-    display: flex;
-    align-items: center;
-    gap: 5px;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }
 
 .stat-card .change.positive {
-    color: var(--success-color);
+  color: var(--success-color);
 }
 
 .stat-card .change.negative {
-    color: var(--error-color);
+  color: var(--error-color);
 }
 
 .stat-card .change.neutral {
-    color: #94a3b8;
+  color: #94a3b8;
 }
 
 .skeleton {
-    background-color: var(--skeleton-color);
-    border-radius: 4px;
-    position: relative;
-    overflow: hidden;
+  background-color: var(--skeleton-color);
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
 }
 
 .skeleton::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.05), transparent);
-    animation: shimmer 1.5s infinite;
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.05),
+    transparent
+  );
+  animation: shimmer 1.5s infinite;
 }
 
 @keyframes shimmer {
-    0% { transform: translateX(-100%); }
-    100% { transform: translateX(100%); }
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 .skeleton-title {
-    width: 60%;
-    height: 16px;
-    margin-bottom: 12px;
+  width: 60%;
+  height: 16px;
+  margin-bottom: 12px;
 }
 
 .skeleton-value {
-    width: 80%;
-    height: 32px;
-    margin-bottom: 8px;
+  width: 80%;
+  height: 32px;
+  margin-bottom: 8px;
 }
 
 .skeleton-change {
-    width: 50%;
-    height: 14px;
+  width: 50%;
+  height: 14px;
 }
 
 .skeleton-avatar {
-    width: 35px;
-    height: 35px;
-    border-radius: 50%;
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
 }
 
 .skeleton-text {
-    height: 16px;
-    border-radius: 4px;
+  height: 16px;
+  border-radius: 4px;
 }
 
 .skeleton-row {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 15px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 15px;
 }
 
 .skeleton-row .skeleton-text {
-    flex: 1;
+  flex: 1;
 }
 
 .activity-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 .activity-item {
-    display: flex;
-    align-items: center;
-    padding: 8px 0;
-    border-bottom: 1px solid var(--border-color);
-    font-size: 14px;
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 14px;
 }
 
 .activity-item:last-child {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .admin-tools-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 15px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
 }
 
 .admin-tool-card {
-    width: 150px;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    padding: 10px;
-    text-align: center;
-    background-color: var(--primary-light);
+  width: 150px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 10px;
+  text-align: center;
+  background-color: var(--primary-light);
 }
 
 .admin-tool-card img {
-    width: 100%;
-    height: 80px;
-    object-fit: cover;
-    border-radius: 4px;
-    margin-bottom: 8px;
-    background-color: rgba(255,255,255,0.1);
+  width: 100%;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 8px;
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 .admin-tool-card .tool-title {
-    font-size: 14px;
-    font-weight: 600;
-    margin-bottom: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 4px;
 }
 
 .admin-tool-card .tool-status {
-    font-size: 12px;
-    color: var(--info-color);
+  font-size: 12px;
+  color: var(--info-color);
 }
 
 .activity-date {
-    width: 130px;
-    color: #94a3b8;
-    font-size: 12px;
+  width: 130px;
+  color: #94a3b8;
+  font-size: 12px;
 }
 
 .activity-action {
-    flex: 1;
-    margin: 0 10px;
+  flex: 1;
+  margin: 0 10px;
 }
 
 .activity-success {
-    color: var(--success-color);
+  color: var(--success-color);
 }
 
 .activity-fail {
-    color: var(--error-color);
+  color: var(--error-color);
 }
 
 .admin-table-container {
-    background: var(--card-bg);
-    border-radius: 12px;
-    padding: 20px;
-    backdrop-filter: blur(5px);
-    -webkit-backdrop-filter: blur(5px);
-    border: 1px solid var(--border-color);
-    margin-bottom: 30px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 20px;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid var(--border-color);
+  margin-bottom: 30px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .table-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
 }
 
 .header-actions {
-    display: flex;
-    align-items: center;
-    gap: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .table-title {
-    font-size: 20px;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .search-box {
-    position: relative;
-    width: 300px;
+  position: relative;
+  width: 300px;
 }
 
 .search-box input {
-    width: 100%;
-    padding: 10px 15px 10px 40px;
-    border-radius: 20px;
-    border: 1px solid var(--border-color);
-    background-color: rgba(255, 255, 255, 0.1);
-    color: var(--text-color);
-    outline: none;
-    transition: all 0.3s ease;
-    font-size: 14px;
+  width: 100%;
+  padding: 10px 15px 10px 40px;
+  border-radius: 20px;
+  border: 1px solid var(--border-color);
+  background-color: rgba(255, 255, 255, 0.1);
+  color: var(--text-color);
+  outline: none;
+  transition: all 0.3s ease;
+  font-size: 14px;
 }
 
 .light-theme .search-box input {
-    background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .search-box input:focus {
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
 }
 
 .search-box i {
-    position: absolute;
-    left: 15px;
-    top: 50%;
-    transform: translateY(-50%);
-    color: #94a3b8;
-    font-size: 16px;
+  position: absolute;
+  left: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #94a3b8;
+  font-size: 16px;
 }
 
 .admin-table {
-    width: 100%;
-    border-collapse: collapse;
+  width: 100%;
+  border-collapse: collapse;
 }
 
 .admin-table th {
-    text-align: left;
-    padding: 12px 15px;
-    font-weight: 500;
-    color: #94a3b8;
-    border-bottom: 1px solid var(--border-color);
-    font-size: 14px;
+  text-align: left;
+  padding: 12px 15px;
+  font-weight: 500;
+  color: #94a3b8;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 14px;
 }
 
 .admin-table td {
-    padding: 15px;
-    border-bottom: 1px solid var(--border-color);
-    vertical-align: middle;
-    font-size: 14px;
+  padding: 15px;
+  border-bottom: 1px solid var(--border-color);
+  vertical-align: middle;
+  font-size: 14px;
 }
 
 .admin-table tr:last-child td {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .admin-table tr:hover td {
-    background-color: var(--primary-light);
+  background-color: var(--primary-light);
 }
 
 .user-cell {
-    display: flex;
-    align-items: center;
-    gap: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .user-avatar-sm {
-    width: 35px;
-    height: 35px;
-    border-radius: 50%;
-    object-fit: cover;
-    border: 2px solid var(--primary-color);
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--primary-color);
 }
 
 .user-info {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .user-name {
-    font-weight: 500;
+  font-weight: 500;
 }
 
 .user-email {
-    font-size: 12px;
-    color: #94a3b8;
+  font-size: 12px;
+  color: #94a3b8;
 }
 
 .status-badge {
-    padding: 5px 10px;
-    border-radius: 20px;
-    font-size: 12px;
-    font-weight: 500;
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
+  padding: 5px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
 }
 
 .status-active {
-    background-color: rgba(16, 185, 129, 0.2);
-    color: var(--success-color);
+  background-color: rgba(16, 185, 129, 0.2);
+  color: var(--success-color);
 }
 
 .status-banned {
-    background-color: rgba(239, 68, 68, 0.2);
-    color: var(--error-color);
+  background-color: rgba(239, 68, 68, 0.2);
+  color: var(--error-color);
 }
 
 .status-pending {
-    background-color: rgba(245, 158, 11, 0.2);
-    color: var(--warning-color);
+  background-color: rgba(245, 158, 11, 0.2);
+  color: var(--warning-color);
 }
 
 .action-btn {
-    padding: 8px;
-    border-radius: 8px;
-    border: none;
-    background-color: transparent;
-    color: var(--text-color);
-    cursor: pointer;
-    transition: all 0.3s ease;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
+  padding: 8px;
+  border-radius: 8px;
+  border: none;
+  background-color: transparent;
+  color: var(--text-color);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
 }
 
 .action-btn:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 .action-btn.edit {
-    color: var(--primary-color);
+  color: var(--primary-color);
 }
 
 .action-btn.delete {
-    color: var(--error-color);
+  color: var(--error-color);
 }
 
 .action-btn.view {
-    color: var(--info-color);
+  color: var(--info-color);
 }
 
 .action-btn i {
-    font-size: 18px;
+  font-size: 18px;
 }
 
 .pagination {
-    display: flex;
-    justify-content: center;
-    gap: 10px;
-    margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 20px;
 }
 
 .page-btn {
-    width: 40px;
-    height: 40px;
-    border-radius: 8px;
-    border: 1px solid var(--border-color);
-    background-color: transparent;
-    color: var(--text-color);
-    cursor: pointer;
-    transition: all 0.3s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background-color: transparent;
+  color: var(--text-color);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .page-btn.active {
-    background-color: var(--primary-color);
-    border-color: var(--primary-color);
-    color: white;
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  color: white;
 }
 
 .page-btn:hover:not(.active) {
-    background-color: var(--primary-light);
+  background-color: var(--primary-light);
 }
 
 .page-btn i {
-    font-size: 18px;
+  font-size: 18px;
 }
 
 .modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.7);
-    backdrop-filter: blur(5px);
-    -webkit-backdrop-filter: blur(5px);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 2000;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.3s ease;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
 }
 
 .modal-overlay.active {
-    opacity: 1;
-    pointer-events: all;
+  opacity: 1;
+  pointer-events: all;
 }
 
 .user-modal {
-    background-color: var(--card-bg);
-    border-radius: 12px;
-    width: 800px;
-    max-width: 90%;
-    max-height: 90vh;
-    overflow-y: auto;
-    border: 1px solid var(--border-color);
-    transform: translateY(20px);
-    transition: transform 0.3s ease;
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  background-color: var(--card-bg);
+  border-radius: 12px;
+  width: 800px;
+  max-width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  border: 1px solid var(--border-color);
+  transform: translateY(20px);
+  transition: transform 0.3s ease;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
 }
 
 .confirm-modal {
-    background-color: var(--card-bg);
-    border-radius: 12px;
-    width: 500px;
-    max-width: 90%;
-    border: 1px solid var(--border-color);
-    transform: translateY(20px);
-    transition: transform 0.3s ease;
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  background-color: var(--card-bg);
+  border-radius: 12px;
+  width: 500px;
+  max-width: 90%;
+  border: 1px solid var(--border-color);
+  transform: translateY(20px);
+  transition: transform 0.3s ease;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
 }
 
 .modal-overlay.active .user-modal {
-    transform: translateY(0);
+  transform: translateY(0);
 }
 
 .modal-overlay.active .confirm-modal {
-    transform: translateY(0);
+  transform: translateY(0);
 }
 
 .modal-header {
-    padding: 20px;
-    border-bottom: 1px solid var(--border-color);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  padding: 20px;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .modal-title {
-    font-size: 22px;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 10px;
+  font-size: 22px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .close-modal {
-    background: none;
-    border: none;
-    font-size: 24px;
-    color: #94a3b8;
-    cursor: pointer;
-    transition: color 0.3s ease;
-    width: 40px;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: color 0.3s ease;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
 }
 
 .close-modal:hover {
-    background-color: rgba(239, 68, 68, 0.1);
-    color: var(--error-color);
+  background-color: rgba(239, 68, 68, 0.1);
+  color: var(--error-color);
 }
 
 .modal-body {
-    padding: 20px;
+  padding: 20px;
 }
 
 .user-profile-header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 30px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 30px;
 }
 
 .user-avatar-lg {
-    width: 100px;
-    height: 100px;
-    border-radius: 50%;
-    object-fit: cover;
-    border: 3px solid var(--primary-color);
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid var(--primary-color);
 }
 
 .user-details {
-    flex: 1;
+  flex: 1;
 }
 
 .user-name-wrapper {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .verified-icon {
-    width: 16px;
-    height: 16px;
-    vertical-align: middle;
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
 }
 
 .user-name-lg {
-    font-size: 24px;
-    font-weight: 600;
-    margin-bottom: 5px;
+  font-size: 24px;
+  font-weight: 600;
+  margin-bottom: 5px;
 }
 
 .user-role {
-    display: inline-flex;
-    align-items: center;
-    margin-top: 7px;
-    margin-left: 5px;
-    gap: 5px;
-    padding: 3px 10px;
-    border-radius: 20px;
-    font-size: 12px;
-    font-weight: 500;
-    margin-bottom: 10px;
+  display: inline-flex;
+  align-items: center;
+  margin-top: 7px;
+  margin-left: 5px;
+  gap: 5px;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 10px;
 }
 
 .ban-info {
-    margin-top: 8px;
-    font-weight: 600;
-    color: var(--error-color);
-    display: flex;
-    align-items: center;
-    gap: 10px;
+  margin-top: 8px;
+  font-weight: 600;
+  color: var(--error-color);
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .role-admin {
-    background-color: rgba(239, 68, 68, 0.2);
-    color: #ef4444;
+  background-color: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
 }
 
 .role-moderator {
-    background-color: rgba(99, 102, 241, 0.2);
-    color: var(--primary-color);
+  background-color: rgba(99, 102, 241, 0.2);
+  color: var(--primary-color);
 }
 
 .role-user {
-    background-color: rgba(16, 185, 129, 0.2);
-    color: var(--success-color);
+  background-color: rgba(16, 185, 129, 0.2);
+  color: var(--success-color);
 }
 
 .user-stats {
-    display: flex;
-    gap: 20px;
+  display: flex;
+  gap: 20px;
 }
 
 .user-stat {
-    text-align: center;
-    background: rgba(255, 255, 255, 0.05);
-    padding: 10px 15px;
-    border-radius: 8px;
-    min-width: 80px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 10px 15px;
+  border-radius: 8px;
+  min-width: 80px;
 }
 
 .stat-number {
-    font-size: 20px;
-    font-weight: 600;
+  font-size: 20px;
+  font-weight: 600;
 }
 
 .stat-label {
-    font-size: 12px;
-    color: #94a3b8;
+  font-size: 12px;
+  color: #94a3b8;
 }
 
 .user-tabs {
-    display: flex;
-    border-bottom: 1px solid var(--border-color);
-    margin-bottom: 20px;
+  display: flex;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 20px;
 }
 
 .user-tab {
-    padding: 12px 20px;
-    cursor: pointer;
-    font-weight: 500;
-    transition: all 0.3s ease;
-    border-bottom: 2px solid transparent;
-    font-size: 14px;
-    color: #94a3b8;
+  padding: 12px 20px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: all 0.3s ease;
+  border-bottom: 2px solid transparent;
+  font-size: 14px;
+  color: #94a3b8;
 }
 
 .user-tab.active {
-    border-bottom: 2px solid var(--primary-color);
-    color: var(--primary-color);
+  border-bottom: 2px solid var(--primary-color);
+  color: var(--primary-color);
 }
 
 .tab-content {
-    display: none;
+  display: none;
 }
 
 .tab-content.active {
-    display: block;
+  display: block;
 }
 
 .form-group {
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .form-group label {
-    display: block;
-    margin-bottom: 8px;
-    font-weight: 500;
-    font-size: 14px;
-    color: var(--text-color);
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--text-color);
 }
 
 .form-control {
-    width: 100%;
-    padding: 10px 15px;
-    border-radius: 8px;
-    border: 1px solid var(--border-color);
-    background-color: rgba(255, 255, 255, 0.05);
-    color: var(--text-color);
-    transition: all 0.3s ease;
-    font-size: 14px;
+  width: 100%;
+  padding: 10px 15px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background-color: rgba(255, 255, 255, 0.05);
+  color: var(--text-color);
+  transition: all 0.3s ease;
+  font-size: 14px;
 }
 
 .light-theme .form-control {
-    background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .form-control:focus {
-    border-color: var(--primary-color);
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  border-color: var(--primary-color);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
 }
 
 .form-row {
-    display: flex;
-    gap: 20px;
+  display: flex;
+  gap: 20px;
 }
 
 .form-row .form-group {
-    flex: 1;
+  flex: 1;
 }
 
 .modal-footer {
-    padding: 20px;
-    border-top: 1px solid var(--border-color);
-    display: flex;
-    justify-content: flex-end;
-    gap: 10px;
+  padding: 20px;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
 }
 
 .btn {
-    padding: 10px 20px;
-    border-radius: 8px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    border: none;
-    font-size: 14px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: none;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: 18px;
+  padding: 4px 8px;
+  transition: color 0.2s ease;
+}
+
+.icon-btn:hover {
+  color: var(--primary-color);
 }
 
 .btn-sm {
-    padding: 4px 8px;
-    font-size: 12px;
-    background-color: var(--info-color);
+  padding: 4px 8px;
+  font-size: 12px;
+  background-color: var(--info-color);
 }
 
 .btn-primary {
-    background-color: var(--primary-color);
-    color: white;
+  background-color: var(--primary-color);
+  color: white;
 }
 
 .btn-primary:hover {
-    background-color: #4f46e5;
+  background-color: #4f46e5;
 }
 
 .btn-secondary {
-    background-color: transparent;
-    border: 1px solid var(--border-color);
-    color: var(--text-color);
+  background-color: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-color);
 }
 
 .btn-secondary:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 .btn-danger {
-    background-color: var(--error-color);
-    color: white;
+  background-color: var(--error-color);
+  color: white;
 }
 
 #clear-logs-btn {
-    padding: var(--clear-btn-padding);
+  padding: var(--clear-btn-padding);
 }
 
 .btn-danger:hover {
-    background-color: #dc2626;
+  background-color: #dc2626;
 }
 
 .hidden {
-    display: none;
+  display: none;
 }
 
 .toast-container {
-    position: fixed;
-    top: 20px;
-    right: 20px;
-    z-index: 3000;
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 3000;
 }
 
 .toast {
-    padding: 15px 20px;
-    border-radius: 8px;
-    margin-bottom: 10px;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    transform: translateX(100%);
-    opacity: 0;
-    transition: all 0.3s ease;
-    max-width: 350px;
+  padding: 15px 20px;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: translateX(100%);
+  opacity: 0;
+  transition: all 0.3s ease;
+  max-width: 350px;
 }
 
 .toast.show {
-    transform: translateX(0);
-    opacity: 1;
+  transform: translateX(0);
+  opacity: 1;
 }
 
 .toast.success {
-    background-color: var(--success-color);
-    color: white;
+  background-color: var(--success-color);
+  color: white;
 }
 
 .toast.error {
-    background-color: var(--error-color);
-    color: white;
+  background-color: var(--error-color);
+  color: white;
 }
 
 .toast.warning {
-    background-color: var(--warning-color);
-    color: white;
+  background-color: var(--warning-color);
+  color: white;
 }
 
 .toast.info {
-    background-color: var(--info-color);
-    color: white;
+  background-color: var(--info-color);
+  color: white;
 }
 
 .toast-icon {
-    font-size: 20px;
+  font-size: 20px;
 }
 
 .toast-close {
-    margin-left: auto;
-    background: none;
-    border: none;
-    color: inherit;
-    cursor: pointer;
-    font-size: 16px;
-    opacity: 0.8;
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  opacity: 0.8;
 }
 
 .toast-close:hover {
-    opacity: 1;
+  opacity: 1;
 }
 
 @media (max-width: 1200px) {
-    .stats-cards {
+  .stats-cards {
     grid-template-columns: repeat(2, 1fr);
-    }
+  }
 }
 
 @media (max-width: 992px) {
-    .admin-sidebar {
+  .admin-sidebar {
     transform: translateX(-100%);
-    }
-    
-    .admin-sidebar.active {
+  }
+
+  .admin-sidebar.active {
     transform: translateX(0);
-    }
-    
-    .admin-content {
+  }
+
+  .admin-content {
     margin-left: 0;
-    }
+  }
 }
 
 @media (max-width: 768px) {
-    .stats-cards {
+  .stats-cards {
     grid-template-columns: 1fr;
-    }
-    
-    .search-box {
+  }
+
+  .search-box {
     width: 100%;
-    }
-    
-    .table-header {
+  }
+
+  .table-header {
     flex-direction: column;
     align-items: flex-start;
     gap: 15px;
-    }
-    
-    .user-profile-header {
+  }
+
+  .user-profile-header {
     flex-direction: column;
     text-align: center;
-    }
-    
-    .user-stats {
+  }
+
+  .user-stats {
     justify-content: center;
-    }
-    
-    .form-row {
+  }
+
+  .form-row {
     flex-direction: column;
     gap: 0;
-    }
+  }
 }
 
 .access-denied {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: calc(100vh - 70px);
-    text-align: center;
-    padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 70px);
+  text-align: center;
+  padding: 20px;
 }
 
 .access-denied i {
-    font-size: 80px;
-    color: var(--error-color);
-    margin-bottom: 20px;
+  font-size: 80px;
+  color: var(--error-color);
+  margin-bottom: 20px;
 }
 
 .access-denied h2 {
-    font-size: 28px;
-    margin-bottom: 15px;
-    color: var(--error-color);
+  font-size: 28px;
+  margin-bottom: 15px;
+  color: var(--error-color);
 }
 
 .access-denied p {
-    font-size: 16px;
-    margin-bottom: 25px;
-    max-width: 500px;
-    color: #94a3b8;
+  font-size: 16px;
+  margin-bottom: 25px;
+  max-width: 500px;
+  color: #94a3b8;
 }
 
 .access-denied .btn {
-    margin-top: 15px;
+  margin-top: 15px;
 }
 
 .access-denied i.fas.fa-home {
-    font-size: 24px;
-    color: var(--secondary-color);
-    margin-bottom: -0px;
+  font-size: 24px;
+  color: var(--secondary-color);
+  margin-bottom: -0px;
 }

--- a/frontend/src/JS/account/index.js
+++ b/frontend/src/JS/account/index.js
@@ -2,680 +2,786 @@ let apiBaseURL = window.API_BASE_URL;
 let currentUserData = null;
 let twoFactorEnabled = false;
 
-document.addEventListener('DOMContentLoaded', () => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const emailVerified = urlParams.get('event') === 'email_verified';
-    
-    if (emailVerified) {
-        showSuccessModal("Email vérifié !", "Votre adresse email a été vérifiée avec succès. Vous pouvez maintenant profiter pleinement de votre compte ToolCenter.");
-    }
-    
-    const token = localStorage.getItem('token');
-    
-    if (!token) {
-        showAuthInterface();
-    } else {
-        showMainContent();
-        
-        Promise.resolve()
-            .then(() => fetchUserData())
-            .then(() => fetchSanctions())
-            .then(() => {
-                initAvatarModal();
-                initEmailModal();
-                initUsernameModal();
-                initTheme();
-            })
-            .catch(error => {
-                console.error('Erreur:', error);
-                showError("Impossible de se connecter au serveur. Veuillez réessayer plus tard.");
-                setTimeout(() => {
-                    hideMainContent();
-                    showAuthInterface();
-                }, 300);
-            });
-    }
-    
-    const url = new URL(window.location.href);
-    const tok = url.searchParams.get("token");
-    if (tok) {
-        localStorage.setItem("token", tok);
-        url.searchParams.delete("token");
-        history.replaceState({}, "", url);
-        window.location.reload();
-    }
+document.addEventListener("DOMContentLoaded", () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const emailVerified = urlParams.get("event") === "email_verified";
+
+  if (emailVerified) {
+    showSuccessModal(
+      "Email vérifié !",
+      "Votre adresse email a été vérifiée avec succès. Vous pouvez maintenant profiter pleinement de votre compte ToolCenter.",
+    );
+  }
+
+  const token = localStorage.getItem("token");
+
+  if (!token) {
+    showAuthInterface();
+  } else {
+    showMainContent();
+
+    Promise.resolve()
+      .then(() => fetchUserData())
+      .then(() => fetchSanctions())
+      .then(() => {
+        initAvatarModal();
+        initEmailModal();
+        initUsernameModal();
+        initTheme();
+      })
+      .catch((error) => {
+        console.error("Erreur:", error);
+        showError(
+          "Impossible de se connecter au serveur. Veuillez réessayer plus tard.",
+        );
+        setTimeout(() => {
+          hideMainContent();
+          showAuthInterface();
+        }, 300);
+      });
+  }
+
+  const url = new URL(window.location.href);
+  const tok = url.searchParams.get("token");
+  if (tok) {
+    localStorage.setItem("token", tok);
+    url.searchParams.delete("token");
+    history.replaceState({}, "", url);
+    window.location.reload();
+  }
 });
 
 function showAuthInterface() {
-    document.getElementById('authContainer').classList.add('active');
-    document.getElementById('mainContentContainer').classList.remove('active');
-    document.getElementById('mainHeader').classList.remove('active');
-    document.getElementById('mainContainer').classList.remove('active');
+  document.getElementById("authContainer").classList.add("active");
+  document.getElementById("mainContentContainer").classList.remove("active");
+  document.getElementById("mainHeader").classList.remove("active");
+  document.getElementById("mainContainer").classList.remove("active");
 }
 
 function showMainContent() {
-    document.getElementById('authContainer').classList.remove('active');
-    document.getElementById('mainContentContainer').classList.add('active');
-    document.getElementById('mainHeader').classList.add('active');
-    document.getElementById('mainContainer').classList.add('active');
+  document.getElementById("authContainer").classList.remove("active");
+  document.getElementById("mainContentContainer").classList.add("active");
+  document.getElementById("mainHeader").classList.add("active");
+  document.getElementById("mainContainer").classList.add("active");
 }
 
 function hideMainContent() {
-    document.getElementById('mainContentContainer').classList.remove('active');
-    document.getElementById('mainHeader').classList.remove('active');
-    document.getElementById('mainContainer').classList.remove('active');
+  document.getElementById("mainContentContainer").classList.remove("active");
+  document.getElementById("mainHeader").classList.remove("active");
+  document.getElementById("mainContainer").classList.remove("active");
 }
 
 function showError(message) {
-    const errorContainer = document.getElementById('errorContainer');
-    errorContainer.innerHTML = `
+  const errorContainer = document.getElementById("errorContainer");
+  errorContainer.innerHTML = `
         <div class="error-message">
             <img src="/assets/error.png" alt="Erreur" class="error-icon">
             <span>${message}</span>
         </div>
     `;
-    errorContainer.classList.remove('hidden');
+  errorContainer.classList.remove("hidden");
 }
 
 function showSuccessModal(title, description) {
-    const successModal = document.getElementById('successModal');
-    successModal.classList.add('active');
+  const successModal = document.getElementById("successModal");
+  successModal.classList.add("active");
 
-    const successTitle = document.querySelector('.success-title');
-    const successMessage = document.querySelector('.success-message');
+  const successTitle = document.querySelector(".success-title");
+  const successMessage = document.querySelector(".success-message");
 
-    successTitle.textContent = title;
-    successMessage.textContent = description;
+  successTitle.textContent = title;
+  successMessage.textContent = description;
 
-    document.getElementById('successModalClose').addEventListener('click', () => {
-    successModal.classList.remove('active');
+  document.getElementById("successModalClose").addEventListener("click", () => {
+    successModal.classList.remove("active");
 
     const url = new URL(window.location.href);
-    url.searchParams.delete('event');
-    window.history.replaceState({}, '', url);
-    });
+    url.searchParams.delete("event");
+    window.history.replaceState({}, "", url);
+  });
 }
 
 function fetchUserData() {
-    const token = localStorage.getItem('token');
-    
-    return fetch(`${apiBaseURL}/user/me`, {
-        method: 'GET',
-        headers: {
-            'Authorization': `Bearer ${token}`
+  const token = localStorage.getItem("token");
+
+  return fetch(`${apiBaseURL}/user/me`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+    .then((response) => {
+      if (!response.ok) {
+        if (response.status === 401) {
+          localStorage.removeItem("token");
+          throw new Error("Votre session a expiré. Veuillez vous reconnecter.");
         }
+        throw new Error(
+          "Erreur lors de la récupération des données utilisateur",
+        );
+      }
+      return response.json();
     })
-    .then(response => {
-        if (!response.ok) {
-            if (response.status === 401) {
-                localStorage.removeItem('token');
-                throw new Error("Votre session a expiré. Veuillez vous reconnecter.");
-            }
-            throw new Error('Erreur lors de la récupération des données utilisateur');
-        }
-        return response.json();
-    })
-    .then(data => {
-        if (data.success) {
-            currentUserData = data.user;
-            twoFactorEnabled = data.user.two_factor_enabled === true;
-            displayUserData(data.user);
-            return data;
-        } else {
-            throw new Error(data.message || "Erreur lors de la récupération des données utilisateur");
-        }
+    .then((data) => {
+      if (data.success) {
+        currentUserData = data.user;
+        twoFactorEnabled = data.user.two_factor_enabled === true;
+        displayUserData(data.user);
+        return data;
+      } else {
+        throw new Error(
+          data.message ||
+            "Erreur lors de la récupération des données utilisateur",
+        );
+      }
     });
 }
 
 function checkTwoFactorStatus() {
-    const token = localStorage.getItem('token');
-    return fetch(`${apiBaseURL}/user/me`, { headers: { 'Authorization': `Bearer ${token}` } })
-        .then(r => r.json())
-        .then(d => { if (d.success) twoFactorEnabled = d.user.two_factor_enabled === true; });
+  const token = localStorage.getItem("token");
+  return fetch(`${apiBaseURL}/user/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+    .then((r) => r.json())
+    .then((d) => {
+      if (d.success) twoFactorEnabled = d.user.two_factor_enabled === true;
+    });
 }
 
 function displayUserData(userData) {
-    document.querySelectorAll('.skeleton').forEach(el => {
-        el.classList.add('fade-out');
-        setTimeout(() => {
-            document.getElementById('skeleton-status-text').classList.add('fade-out');
-            document.getElementById('skeleton-status-desc').classList.add('fade-out');
-            document.getElementById('skeleton-status-bar').classList.add('fade-out');
-            
-            setTimeout(() => {
-                document.getElementById('accountStatusText').style.display = 'inline';
-                document.getElementById('statusDescription').style.display = 'block';
-                document.getElementById('statusProgress').style.display = 'block';
-                setAccountStatus(userData.account_status);
-                el.classList.add('hidden');
-            }, 300);
-        }, 300);
-    });
-
+  document.querySelectorAll(".skeleton").forEach((el) => {
+    el.classList.add("fade-out");
     setTimeout(() => {
-        const usernameEl=document.getElementById("username")
-        const name=userData.username
-        usernameEl.textContent=''
-        ;[...name].forEach((ch,i)=>{
-            const span=document.createElement('span')
-            span.textContent=ch
-            span.style.setProperty('--i',i)
-            span.className='letter'
-            usernameEl.appendChild(span)
-        })
-        usernameEl.classList.add('active')
-        
-        const createdAt = new Date(userData.created_at);
-        document.getElementById("member-date").textContent = `Membre depuis ${createdAt.toLocaleDateString('fr-FR')}`;
-        document.getElementById("member-date").classList.add('active');
-        
-        if (userData.avatar_url) {
-            document.getElementById("avatar").src = userData.avatar_url;
-        } else {
-            document.getElementById("avatar").src = "/assets/account.png";
-        }
-        document.getElementById("avatar").classList.add('active');
+      document.getElementById("skeleton-status-text").classList.add("fade-out");
+      document.getElementById("skeleton-status-desc").classList.add("fade-out");
+      document.getElementById("skeleton-status-bar").classList.add("fade-out");
 
-        const email = userData.email;
-        const [localPart, domain] = email.split("@");
-        const hiddenEmail = localPart.replace(/./g, "*") + "@" + domain;
-
-        document.getElementById("email").textContent = hiddenEmail;
-        document.getElementById("email").dataset.fullEmail = email;
-        document.getElementById("email").classList.add('active');
-        
-        document.getElementById("toggleEmail").classList.add('active');
-        document.getElementById("editEmail").classList.add('active');
-
-        if (userData.is_verified) {
-            document.getElementById("verified-badge").classList.add('active');
-        }
-
-        document.getElementById("tools-count").textContent = userData.stats.tools_posted || 0;
-        document.getElementById("likes-count").textContent = userData.stats.likes_received || 0;
-        document.getElementById("views-count").textContent = "0";
-        document.getElementById("followers-count").textContent = "0";
-        
-        document.querySelectorAll('.stat-value').forEach(el => el.classList.add('active'));
-        document.querySelectorAll('.stat-label').forEach(el => el.classList.add('active'));
-
-        animateCounters();
-
-        document.getElementById('toggleEmail').addEventListener('click', function() {
-            const emailSpan = document.getElementById('email');
-            const isHidden = emailSpan.textContent.includes('*');
-            
-            emailSpan.textContent = isHidden ? emailSpan.dataset.fullEmail : hiddenEmail;
-            this.src = isHidden ? '/assets/dont-show.png' : '/assets/show.png';
-            
-            emailSpan.style.animation = 'none';
-            setTimeout(() => {
-                emailSpan.style.animation = 'fadeIn 0.3s ease';
-            }, 10);
-        });
+      setTimeout(() => {
+        document.getElementById("accountStatusText").style.display = "inline";
+        document.getElementById("statusDescription").style.display = "block";
+        document.getElementById("statusProgress").style.display = "block";
+        setAccountStatus(userData.account_status);
+        el.classList.add("hidden");
+      }, 300);
     }, 300);
+  });
+
+  setTimeout(() => {
+    const usernameEl = document.getElementById("username");
+    const name = userData.username;
+    usernameEl.textContent = "";
+    [...name].forEach((ch, i) => {
+      const span = document.createElement("span");
+      span.textContent = ch;
+      span.style.setProperty("--i", i);
+      span.className = "letter";
+      usernameEl.appendChild(span);
+    });
+    usernameEl.classList.add("active");
+
+    const createdAt = new Date(userData.created_at);
+    document.getElementById("member-date").textContent =
+      `Membre depuis ${createdAt.toLocaleDateString("fr-FR")}`;
+    document.getElementById("member-date").classList.add("active");
+
+    if (userData.avatar_url) {
+      document.getElementById("avatar").src = userData.avatar_url;
+    } else {
+      document.getElementById("avatar").src = "/assets/account.png";
+    }
+    document.getElementById("avatar").classList.add("active");
+
+    const email = userData.email;
+    const [localPart, domain] = email.split("@");
+    const hiddenEmail = localPart.replace(/./g, "*") + "@" + domain;
+
+    document.getElementById("email").textContent = hiddenEmail;
+    document.getElementById("email").dataset.fullEmail = email;
+    document.getElementById("email").classList.add("active");
+
+    document.getElementById("toggleEmail").classList.add("active");
+    document.getElementById("editEmail").classList.add("active");
+
+    if (userData.is_verified) {
+      document.getElementById("verified-badge").classList.add("active");
+    }
+
+    document.getElementById("tools-count").textContent =
+      userData.stats.tools_posted || 0;
+    document.getElementById("likes-count").textContent =
+      userData.stats.likes_received || 0;
+    document.getElementById("views-count").textContent = "0";
+    document.getElementById("followers-count").textContent = "0";
+
+    document
+      .querySelectorAll(".stat-value")
+      .forEach((el) => el.classList.add("active"));
+    document
+      .querySelectorAll(".stat-label")
+      .forEach((el) => el.classList.add("active"));
+
+    animateCounters();
+
+    document
+      .getElementById("toggleEmail")
+      .addEventListener("click", function () {
+        const emailSpan = document.getElementById("email");
+        const isHidden = emailSpan.textContent.includes("*");
+
+        emailSpan.textContent = isHidden
+          ? emailSpan.dataset.fullEmail
+          : hiddenEmail;
+        this.src = isHidden ? "/assets/dont-show.png" : "/assets/show.png";
+
+        emailSpan.style.animation = "none";
+        setTimeout(() => {
+          emailSpan.style.animation = "fadeIn 0.3s ease";
+        }, 10);
+      });
+  }, 300);
 }
 
 function animateCounters() {
-    const counters = document.querySelectorAll('.stat-value');
-    const speed = 200;
-    
-    counters.forEach(counter => {
-        const target = +counter.innerText;
-        let count = 0;
-        
-        const updateCount = () => {
-            if (count < target) {
-                counter.innerText = Math.ceil(count);
-                count += target / speed;
-                requestAnimationFrame(updateCount);
-            } else {
-                counter.innerText = target;
-            }
-        };
-        
-        updateCount();
-    });
+  const counters = document.querySelectorAll(".stat-value");
+  const speed = 200;
+
+  counters.forEach((counter) => {
+    const target = +counter.innerText;
+    let count = 0;
+
+    const updateCount = () => {
+      if (count < target) {
+        counter.innerText = Math.ceil(count);
+        count += target / speed;
+        requestAnimationFrame(updateCount);
+      } else {
+        counter.innerText = target;
+      }
+    };
+
+    updateCount();
+  });
 }
 
 function initTheme() {
-    const themeSwitcher = document.getElementById("theme-switcher");
-    const themeIcon = document.getElementById("theme-icon");
-    const savedTheme = localStorage.getItem("theme");
+  const themeSwitcher = document.getElementById("theme-switcher");
+  const themeIcon = document.getElementById("theme-icon");
+  const savedTheme = localStorage.getItem("theme");
 
-    if (savedTheme === "light") {
-        document.body.classList.add("light-mode");
-        themeIcon.src = "/assets/switcher-noir.png";
-    } else {
-        themeIcon.src = "/assets/switcher.png";
-    }
+  if (savedTheme === "light") {
+    document.body.classList.add("light-mode");
+    themeIcon.src = "/assets/switcher-noir.png";
+  } else {
+    themeIcon.src = "/assets/switcher.png";
+  }
 
-    themeSwitcher.addEventListener("click", () => {
-        const isDarkMode = !document.body.classList.contains("light-mode");
-        const newTheme = isDarkMode ? "light" : "dark";
+  themeSwitcher.addEventListener("click", () => {
+    const isDarkMode = !document.body.classList.contains("light-mode");
+    const newTheme = isDarkMode ? "light" : "dark";
 
-        document.body.classList.toggle("light-mode", newTheme === "light");
+    document.body.classList.toggle("light-mode", newTheme === "light");
 
-        themeIcon.src = newTheme === "dark"
-            ? "/assets/switcher.png"
-            : "/assets/switcher-noir.png";
+    themeIcon.src =
+      newTheme === "dark"
+        ? "/assets/switcher.png"
+        : "/assets/switcher-noir.png";
 
-        localStorage.setItem("theme", newTheme);
-        
-        themeIcon.style.animation = 'none';
-        setTimeout(() => {
-            themeIcon.style.animation = 'float 0.5s ease';
-        }, 10);
-    });
+    localStorage.setItem("theme", newTheme);
+
+    themeIcon.style.animation = "none";
+    setTimeout(() => {
+      themeIcon.style.animation = "float 0.5s ease";
+    }, 10);
+  });
 }
 
 function initEmailModal() {
-    const emailModal = document.getElementById("emailModal");
-    const closeEmailModal = document.getElementById("closeEmailModal");
-    const cancelEmailChange = document.getElementById("cancelEmailChange");
-    const editEmail = document.getElementById("editEmail");
-    const newEmailInput = document.getElementById("newEmail");
-    const currentPasswordInput = document.getElementById("currentPassword");
-    const codeInput = document.getElementById("email2FACode");
-    const confirmEmailChange = document.getElementById("confirmEmailChange");
+  const emailModal = document.getElementById("emailModal");
+  const closeEmailModal = document.getElementById("closeEmailModal");
+  const cancelEmailChange = document.getElementById("cancelEmailChange");
+  const editEmail = document.getElementById("editEmail");
+  const newEmailInput = document.getElementById("newEmail");
+  const currentPasswordInput = document.getElementById("currentPassword");
+  const codeInput = document.getElementById("email2FACode");
+  const confirmEmailChange = document.getElementById("confirmEmailChange");
 
-    editEmail.addEventListener("click", () => {
-        checkTwoFactorStatus().finally(() => {
-            document.getElementById("email2FAGroup").style.display = twoFactorEnabled ? 'block' : 'none';
-            emailModal.classList.add("active");
-            newEmailInput.focus();
-        });
+  editEmail.addEventListener("click", () => {
+    checkTwoFactorStatus().finally(() => {
+      document.getElementById("email2FAGroup").style.display = twoFactorEnabled
+        ? "block"
+        : "none";
+      emailModal.classList.add("active");
+      newEmailInput.focus();
     });
-    closeEmailModal.addEventListener("click", () => {
-        emailModal.classList.remove("active");
-        newEmailInput.value = "";
-        currentPasswordInput.value = "";
-        codeInput.value = "";
-    });
-    cancelEmailChange.addEventListener("click", () => {
-        emailModal.classList.remove("active");
-        newEmailInput.value = "";
-        currentPasswordInput.value = "";
-        codeInput.value = "";
-    });
+  });
+  closeEmailModal.addEventListener("click", () => {
+    emailModal.classList.remove("active");
+    newEmailInput.value = "";
+    currentPasswordInput.value = "";
+    codeInput.value = "";
+  });
+  cancelEmailChange.addEventListener("click", () => {
+    emailModal.classList.remove("active");
+    newEmailInput.value = "";
+    currentPasswordInput.value = "";
+    codeInput.value = "";
+  });
 
-    confirmEmailChange.addEventListener("click", () => {
-        const newEmail = newEmailInput.value.trim();
-        const currentPassword = currentPasswordInput.value.trim();
-        const code = codeInput.value.trim();
+  confirmEmailChange.addEventListener("click", () => {
+    const newEmail = newEmailInput.value.trim();
+    const currentPassword = currentPasswordInput.value.trim();
+    const code = codeInput.value.trim();
 
-        if (!newEmail || !currentPassword) {
-            showError("Veuillez remplir tous les champs");
-            return;
-        }
-        if (twoFactorEnabled && code.length !== 6) {
-            showError("Code 2FA invalide");
-            return;
-        }
+    if (!newEmail || !currentPassword) {
+      showError("Veuillez remplir tous les champs");
+      return;
+    }
+    if (twoFactorEnabled && code.length !== 6) {
+      showError("Code 2FA invalide");
+      return;
+    }
 
-        const spinner = document.createElement("span");
-        spinner.className = "spinner";
-        confirmEmailChange.prepend(spinner);
-        closeEmailModal.disabled = true;
-        cancelEmailChange.disabled = true;
-        confirmEmailChange.disabled = true;
-        const token = localStorage.getItem("token");
+    const spinner = document.createElement("span");
+    spinner.className = "spinner";
+    confirmEmailChange.prepend(spinner);
+    closeEmailModal.disabled = true;
+    cancelEmailChange.disabled = true;
+    confirmEmailChange.disabled = true;
+    const token = localStorage.getItem("token");
 
-        const payload = { new_email: newEmail, current_password: currentPassword };
-        if (twoFactorEnabled) payload.two_factor_code = code;
-        fetch(`${apiBaseURL}/user/update_email`, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": `Bearer ${token}`
-        },
-        body: JSON.stringify(payload)
-        })
-        .then(response => response.json())
-        .then(data => {
+    const payload = { new_email: newEmail, current_password: currentPassword };
+    if (twoFactorEnabled) payload.two_factor_code = code;
+    fetch(`${apiBaseURL}/user/update_email`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => response.json())
+      .then((data) => {
         if (data.success) {
-            currentUserData.email = newEmail;
-            document.getElementById("email").textContent = newEmail;
-            document.getElementById("email").dataset.fullEmail = newEmail;
-            emailModal.classList.remove("active");
-            newEmailInput.value = "";
-            currentPasswordInput.value = "";
-            const emailSpan = document.getElementById("email");
-            emailSpan.style.animation = "none";
-            setTimeout(() => {
+          currentUserData.email = newEmail;
+          document.getElementById("email").textContent = newEmail;
+          document.getElementById("email").dataset.fullEmail = newEmail;
+          emailModal.classList.remove("active");
+          newEmailInput.value = "";
+          currentPasswordInput.value = "";
+          const emailSpan = document.getElementById("email");
+          emailSpan.style.animation = "none";
+          setTimeout(() => {
             emailSpan.style.animation = "pulse 0.5s ease";
-            }, 10);
-            showSuccessModal("Votre email a été modifié avec succès !", "Vous recevrez un email de confirmation à votre nouvelle adresse.");
+          }, 10);
+          showSuccessModal(
+            "Votre email a été modifié avec succès !",
+            "Vous recevrez un email de confirmation à votre nouvelle adresse.",
+          );
         } else {
-            throw new Error(data.message || "Erreur lors de la modification de l'email");
+          throw new Error(
+            data.message || "Erreur lors de la modification de l'email",
+          );
         }
-        })
-        .catch(error => {
-            emailModal.classList.remove("active");
-            console.error("Erreur :", error);
-            showError(error.message || "Une erreur s'est produite lors de la modification de l'email");
-        })
-        .finally(() => {
-            closeEmailModal.disabled = false;
-            cancelEmailChange.disabled = false;
-            confirmEmailChange.disabled = false;
-            spinner.remove();
-        });
-    });
+      })
+      .catch((error) => {
+        emailModal.classList.remove("active");
+        console.error("Erreur :", error);
+        showError(
+          error.message ||
+            "Une erreur s'est produite lors de la modification de l'email",
+        );
+      })
+      .finally(() => {
+        closeEmailModal.disabled = false;
+        cancelEmailChange.disabled = false;
+        confirmEmailChange.disabled = false;
+        spinner.remove();
+      });
+  });
 }
 
 function initAvatarModal() {
-    const avatarModal = document.getElementById("avatarModal");
-    const avatarInput = document.getElementById("avatarInput");
-    const avatarPreview = document.getElementById("avatarPreview");
-    const avatarEditBtn = document.getElementById("avatarEditBtn");
-    const closeAvatarModal = document.getElementById("closeAvatarModal");
-    const cancelAvatarChange = document.getElementById("cancelAvatarChange");
-    const confirmAvatarChange = document.getElementById("confirmAvatarChange");
-    const MAX_SIZE = 5 * 1024 * 1024;
-    const ALLOWED_TYPES = ["image/jpeg","image/png","image/webp"];
-    
-    function previewAvatar(event) {
-        const file = event.target.files && event.target.files[0];
-        if (!file) return;
+  const avatarModal = document.getElementById("avatarModal");
+  const avatarInput = document.getElementById("avatarInput");
+  const avatarPreview = document.getElementById("avatarPreview");
+  const avatarEditBtn = document.getElementById("avatarEditBtn");
+  const closeAvatarModal = document.getElementById("closeAvatarModal");
+  const cancelAvatarChange = document.getElementById("cancelAvatarChange");
+  const confirmAvatarChange = document.getElementById("confirmAvatarChange");
+  const MAX_SIZE = 5 * 1024 * 1024;
+  const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
-        if (!ALLOWED_TYPES.includes(file.type)) {
-            showError("Format d'image non supporté (jpeg, png ou webp)");
-            avatarModal.classList.remove("active");
-            avatarInput.value = "";
-            return;
-        }
+  function previewAvatar(event) {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
 
-        if (file.size > MAX_SIZE) {
-            showError(`Image trop lourde (max ${MAX_SIZE/(1024*1024)} Mo)`);
-            avatarModal.classList.remove("active");
-            avatarInput.value = "";
-            return;
-        }
-
-        const reader = new FileReader();
-
-        reader.onload = function() {
-            avatarPreview.src = reader.result;
-            avatarModal.classList.add("active");
-        };
-
-        reader.readAsDataURL(file);
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      showError("Format d'image non supporté (jpeg, png ou webp)");
+      avatarModal.classList.remove("active");
+      avatarInput.value = "";
+      return;
     }
 
-    avatarEditBtn.addEventListener("click", () => {
-        avatarInput.click();
-    });
-    avatarInput.addEventListener("change", previewAvatar);
-    closeAvatarModal.addEventListener("click", () => {
-        avatarModal.classList.remove("active");
-        avatarInput.value = "";
-    });
-    cancelAvatarChange.addEventListener("click", () => {
-        avatarModal.classList.remove("active");
-        avatarInput.value = "";
-    });
+    if (file.size > MAX_SIZE) {
+      showError(`Image trop lourde (max ${MAX_SIZE / (1024 * 1024)} Mo)`);
+      avatarModal.classList.remove("active");
+      avatarInput.value = "";
+      return;
+    }
 
-    confirmAvatarChange.addEventListener("click", () => {
-        const spinner = document.createElement("span");
-        spinner.className = "spinner";
-        confirmAvatarChange.prepend(spinner);
-        closeAvatarModal.disabled = true;
-        cancelAvatarChange.disabled = true;
-        confirmAvatarChange.disabled = true;
-        const token = localStorage.getItem("token");
-        
-        fetch(avatarPreview.src)
-        .then(res => res.blob())
-        .then(blob => {
-            const formData = new FormData();
-            formData.append("avatar",blob,"avatar.jpg");
-            return fetch(`${apiBaseURL}/user/avatar`, {
-                method: "POST",
-                headers: {
-                    "Authorization": `Bearer ${token}`
-                },
-                body: formData
-            });
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                document.getElementById("avatar").src = avatarPreview.src;
-                const avatar = document.getElementById("avatar");
-                avatar.style.animation = "none";
-                setTimeout(() => {
-                    avatar.style.animation = "pulse 0.5s ease";
-                }, 10);
-                showSuccessModal("Votre avatar a été modifié !", "Votre nouvel avatar sera visible sur votre profil et dans vos outils.");
-            } else {
-                const err = new Error(
-                    data.message || "Erreur lors de la modification de l'avatar"
-                );
-                err.retry_at = data.retry_at;
-                throw err;   
-            }
-        })
-        .catch(error => {
-            if (error.retry_at) {
-                const retryAt = new Date(error.retry_at);
-                const now = new Date();
-                const timeDiff = Math.ceil((retryAt - now) / 1000 / 60 / 60);
-                const retryMessage = `Vous ne pouvez changer votre photo de profil qu'une fois par jour. Réessayez dans ${timeDiff} heure(s).`;
-                showError(retryMessage);
-            } else {
-                showError(error.message || "Une erreur s'est produite lors de la modification de l'avatar");
-            }
-        })
-        .finally(() => {
-            closeAvatarModal.disabled = false;
-            cancelAvatarChange.disabled = false;
-            confirmAvatarChange.disabled = false;
-            spinner.remove();
-            avatarModal.classList.remove("active");
-            avatarInput.value = "";
+    const reader = new FileReader();
+
+    reader.onload = function () {
+      avatarPreview.src = reader.result;
+      avatarModal.classList.add("active");
+    };
+
+    reader.readAsDataURL(file);
+  }
+
+  avatarEditBtn.addEventListener("click", () => {
+    avatarInput.click();
+  });
+  avatarInput.addEventListener("change", previewAvatar);
+  closeAvatarModal.addEventListener("click", () => {
+    avatarModal.classList.remove("active");
+    avatarInput.value = "";
+  });
+  cancelAvatarChange.addEventListener("click", () => {
+    avatarModal.classList.remove("active");
+    avatarInput.value = "";
+  });
+
+  confirmAvatarChange.addEventListener("click", () => {
+    const spinner = document.createElement("span");
+    spinner.className = "spinner";
+    confirmAvatarChange.prepend(spinner);
+    closeAvatarModal.disabled = true;
+    cancelAvatarChange.disabled = true;
+    confirmAvatarChange.disabled = true;
+    const token = localStorage.getItem("token");
+
+    fetch(avatarPreview.src)
+      .then((res) => res.blob())
+      .then((blob) => {
+        const formData = new FormData();
+        formData.append("avatar", blob, "avatar.jpg");
+        return fetch(`${apiBaseURL}/user/avatar`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          body: formData,
         });
-    });
+      })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.success) {
+          document.getElementById("avatar").src = avatarPreview.src;
+          const avatar = document.getElementById("avatar");
+          avatar.style.animation = "none";
+          setTimeout(() => {
+            avatar.style.animation = "pulse 0.5s ease";
+          }, 10);
+          showSuccessModal(
+            "Votre avatar a été modifié !",
+            "Votre nouvel avatar sera visible sur votre profil et dans vos outils.",
+          );
+        } else {
+          const err = new Error(
+            data.message || "Erreur lors de la modification de l'avatar",
+          );
+          err.retry_at = data.retry_at;
+          throw err;
+        }
+      })
+      .catch((error) => {
+        if (error.retry_at) {
+          const retryAt = new Date(error.retry_at);
+          const now = new Date();
+          const timeDiff = Math.ceil((retryAt - now) / 1000 / 60 / 60);
+          const retryMessage = `Vous ne pouvez changer votre photo de profil qu'une fois par jour. Réessayez dans ${timeDiff} heure(s).`;
+          showError(retryMessage);
+        } else {
+          showError(
+            error.message ||
+              "Une erreur s'est produite lors de la modification de l'avatar",
+          );
+        }
+      })
+      .finally(() => {
+        closeAvatarModal.disabled = false;
+        cancelAvatarChange.disabled = false;
+        confirmAvatarChange.disabled = false;
+        spinner.remove();
+        avatarModal.classList.remove("active");
+        avatarInput.value = "";
+      });
+  });
 }
 
 // G0
-document.addEventListener('DOMContentLoaded', () => {
-    const tabMainBtn = document.getElementById('tabMainBtn');
-    const tabStatusBtn = document.getElementById('tabStatusBtn');
-    const tabMain = document.getElementById('tabMain');
-    const tabStatus = document.getElementById('tabStatus');
+document.addEventListener("DOMContentLoaded", () => {
+  const tabMainBtn = document.getElementById("tabMainBtn");
+  const tabStatusBtn = document.getElementById("tabStatusBtn");
+  const tabMain = document.getElementById("tabMain");
+  const tabStatus = document.getElementById("tabStatus");
 
-    tabMainBtn.onclick = function() {
-        tabMainBtn.classList.add('active');
-        tabStatusBtn.classList.remove('active');
-        tabMain.classList.add('active');
-        tabStatus.classList.remove('active');
-    }
-    tabStatusBtn.onclick = function() {
-        tabStatusBtn.classList.add('active');
-        tabMainBtn.classList.remove('active');
-        tabStatus.classList.add('active');
-        tabMain.classList.remove('active');
-    }
+  tabMainBtn.onclick = function () {
+    tabMainBtn.classList.add("active");
+    tabStatusBtn.classList.remove("active");
+    tabMain.classList.add("active");
+    tabStatus.classList.remove("active");
+  };
+  tabStatusBtn.onclick = function () {
+    tabStatusBtn.classList.add("active");
+    tabMainBtn.classList.remove("active");
+    tabStatus.classList.add("active");
+    tabMain.classList.remove("active");
+  };
 });
 
 function initUsernameModal() {
-    const usernameModal = document.getElementById('usernameModal');
-    const newUsernameInput = document.getElementById('newUsername');
-    const closeUsernameModal = document.getElementById('closeUsernameModal');
-    const cancelUsernameChange = document.getElementById('cancelUsernameChange');
-    const confirmUsernameChange = document.getElementById('confirmUsernameChange');
-    const usernameEl = document.getElementById('username');
-    const editBtn = document.getElementById('editUsername');
+  const usernameModal = document.getElementById("usernameModal");
+  const newUsernameInput = document.getElementById("newUsername");
+  const closeUsernameModal = document.getElementById("closeUsernameModal");
+  const cancelUsernameChange = document.getElementById("cancelUsernameChange");
+  const confirmUsernameChange = document.getElementById(
+    "confirmUsernameChange",
+  );
+  const usernameEl = document.getElementById("username");
+  const editBtn = document.getElementById("editUsername");
 
-    editBtn.addEventListener('click', () => {
-        newUsernameInput.value = usernameEl.textContent.trim();
-        usernameModal.classList.add('active');
-        newUsernameInput.focus();
-    });
+  editBtn.addEventListener("click", () => {
+    newUsernameInput.value = usernameEl.textContent.trim();
+    usernameModal.classList.add("active");
+    newUsernameInput.focus();
+  });
 
-    function closeModal() {
-        usernameModal.classList.remove('active');
-        newUsernameInput.value = '';
+  function closeModal() {
+    usernameModal.classList.remove("active");
+    newUsernameInput.value = "";
+  }
+
+  closeUsernameModal.addEventListener("click", closeModal);
+  cancelUsernameChange.addEventListener("click", closeModal);
+
+  confirmUsernameChange.addEventListener("click", () => {
+    const newUsername = newUsernameInput.value.trim();
+    if (newUsername.length < 3 || newUsername.length > 50) {
+      showError("Le pseudo doit contenir entre 3 et 50 caractères.");
+      return;
     }
 
-    closeUsernameModal.addEventListener('click', closeModal);
-    cancelUsernameChange.addEventListener('click', closeModal);
+    const spinner = document.createElement("span");
+    spinner.className = "spinner";
+    confirmUsernameChange.prepend(spinner);
+    closeUsernameModal.disabled = true;
+    cancelUsernameChange.disabled = true;
+    confirmUsernameChange.disabled = true;
 
-    confirmUsernameChange.addEventListener('click', () => {
-        const newUsername = newUsernameInput.value.trim();
-        if (newUsername.length < 3 || newUsername.length > 50) {
-            showError('Le pseudo doit contenir entre 3 et 50 caractères.');
-            return;
+    const token = localStorage.getItem("token");
+    fetch(`${apiBaseURL}/user/update_username`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ username: newUsername }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.success) {
+          usernameEl.textContent = newUsername;
+          showSuccessModal("Pseudo modifié !", "Ton pseudo a été mis à jour !");
+          closeModal();
+        } else {
+          showError(data.message || "Erreur lors de la modification du pseudo");
         }
-
-        const spinner = document.createElement('span');
-        spinner.className = 'spinner';
-        confirmUsernameChange.prepend(spinner);
-        closeUsernameModal.disabled = true;
-        cancelUsernameChange.disabled = true;
-        confirmUsernameChange.disabled = true;
-
-        const token = localStorage.getItem('token');
-        fetch(`${apiBaseURL}/user/update_username`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-            body: JSON.stringify({ username: newUsername })
-        })
-        .then(res => res.json())
-        .then(data => {
-            if (data.success) {
-                usernameEl.textContent = newUsername;
-                showSuccessModal('Pseudo modifié !', 'Ton pseudo a été mis à jour !');
-                closeModal();
-            } else {
-                showError(data.message || 'Erreur lors de la modification du pseudo');
-            }
-        })
-        .catch(() => {
-            showError("Impossible de se connecter au serveur. Veuillez réessayer plus tard.");
-        })
-        .finally(() => {
-            closeUsernameModal.disabled = false;
-            cancelUsernameChange.disabled = false;
-            confirmUsernameChange.disabled = false;
-            spinner.remove();
-        });
-    });
+      })
+      .catch(() => {
+        showError(
+          "Impossible de se connecter au serveur. Veuillez réessayer plus tard.",
+        );
+      })
+      .finally(() => {
+        closeUsernameModal.disabled = false;
+        cancelUsernameChange.disabled = false;
+        confirmUsernameChange.disabled = false;
+        spinner.remove();
+      });
+  });
 }
 
 function setAccountStatus(status) {
-    const bar = document.getElementById('statusProgressFill');
-    const statusText = document.getElementById('accountStatusText');
-    const statusDesc = document.getElementById('statusDescription');
-    const steps = ['Good','Limited','Very Limited','At Risk','Banned'];
-    const colors = [
-        'linear-gradient(90deg,#10c95a,#2fd174)', // Good
-        'linear-gradient(90deg,#ffca29,#ffd66b)', // Limited
-        'linear-gradient(90deg,#f88407,#ff5f00)', // Very Limited
-        'linear-gradient(90deg,#e94434,#fc6a55)', // At Risk
-        'linear-gradient(90deg,#a10000,#570404)'  // Banned
-    ];
-    const descriptions = [
-        "Merci de respecter les règles de ToolCenter !",
-        "Vous ne pouvez plus utiliser certaines parties de ToolCenter. Vous risquez une suspension si vous enfreignez à nouveau les règles.",
-        "Vous ne pouvez plus utiliser la plupart des parties de ToolCenter. Votre compte pourrait être banni.",
-        "Votre compte est à risque. Vous ne pouvez plus utiliser ToolCenter tant que vous n'avez pas réglé le problème.",
-        "Votre compte est banni. Vous ne pouvez plus utiliser ToolCenter."
-    ];
-    const widths = ['10%','30%','50%','70%','100%'];
-    const idx = steps.indexOf(status);
-    if(idx === -1) return;
-    bar.style.width = widths[idx];
-    bar.style.background = colors[idx];
-    statusText.textContent = steps[idx];
-    statusDesc.textContent = descriptions[idx];
+  const bar = document.getElementById("statusProgressFill");
+  const statusText = document.getElementById("accountStatusText");
+  const statusDesc = document.getElementById("statusDescription");
+  const steps = ["Good", "Limited", "Very Limited", "At Risk", "Banned"];
+  const colors = [
+    "linear-gradient(90deg,#10c95a,#2fd174)", // Good
+    "linear-gradient(90deg,#ffca29,#ffd66b)", // Limited
+    "linear-gradient(90deg,#f88407,#ff5f00)", // Very Limited
+    "linear-gradient(90deg,#e94434,#fc6a55)", // At Risk
+    "linear-gradient(90deg,#a10000,#570404)", // Banned
+  ];
+  const descriptions = [
+    "Merci de respecter les règles de ToolCenter !",
+    "Vous ne pouvez plus utiliser certaines parties de ToolCenter. Vous risquez une suspension si vous enfreignez à nouveau les règles.",
+    "Vous ne pouvez plus utiliser la plupart des parties de ToolCenter. Votre compte pourrait être banni.",
+    "Votre compte est à risque. Vous ne pouvez plus utiliser ToolCenter tant que vous n'avez pas réglé le problème.",
+    "Votre compte est banni. Vous ne pouvez plus utiliser ToolCenter.",
+  ];
+  const widths = ["10%", "30%", "50%", "70%", "100%"];
+  const idx = steps.indexOf(status);
+  if (idx === -1) return;
+  bar.style.width = widths[idx];
+  bar.style.background = colors[idx];
+  statusText.textContent = steps[idx];
+  statusDesc.textContent = descriptions[idx];
 }
 
 function fetchSanctions() {
-    const token = localStorage.getItem('token');
-    return fetch(`${apiBaseURL}/user/sanctions`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-    })
-    .then(r => r.json())
-    .then(data => {
-        const sk = document.getElementById('skeleton-sanctions');
-        sk.classList.add('fade-out');
-        setTimeout(() => { sk.style.display = 'none'; }, 300);
-        if(!data.success) return;
-        document.querySelector('.sanctions-section').style.display = 'block';
-        const active = document.getElementById('active-sanctions');
-        const expired = document.getElementById('expired-sanctions');
-        active.innerHTML = '';
-        expired.innerHTML = '';
-        data.active.forEach(s => active.appendChild(createSanctionItem(s, false)));
-        data.expired.forEach(s => expired.appendChild(createSanctionItem(s, true)));
+  const token = localStorage.getItem("token");
+  return fetch(`${apiBaseURL}/user/sanctions`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+    .then((r) => r.json())
+    .then((data) => {
+      const sk = document.getElementById("skeleton-sanctions");
+      sk.classList.add("fade-out");
+      setTimeout(() => {
+        sk.style.display = "none";
+      }, 300);
+      if (!data.success) return;
+      document.querySelector(".sanctions-section").style.display = "block";
+      const active = document.getElementById("active-sanctions");
+      const expired = document.getElementById("expired-sanctions");
+      active.innerHTML = "";
+      expired.innerHTML = "";
+      data.active.forEach((s) =>
+        active.appendChild(createSanctionItem(s, false)),
+      );
+      data.expired.forEach((s) =>
+        expired.appendChild(createSanctionItem(s, true)),
+      );
     });
 }
 
 function createSanctionItem(sanction, expired) {
-    const div = document.createElement('div');
-    div.className = 'sanction-item' + (expired ? ' expired' : '');
-    const icon = document.createElement('img');
-    icon.className = 'sanction-icon';
-    const urls = {
-        Ban: '/assets/error.png',
-        Warn: '/assets/alert.png',
-        Other: '/assets/update.png'
-    };
-    icon.src = urls[sanction.type] || urls.Other;
-    div.appendChild(icon);
-    const label = document.createElement('span');
-    const end = sanction.end ? new Date(sanction.end).toLocaleString('fr-FR') : '';
-    label.textContent = `${sanction.type}${end ? ' (jusqu\u2019au ' + end + ')' : ''}`;
-    div.appendChild(label);
-    div.addEventListener('click', () => openSanctionModal(sanction));
-    return div;
+  sanction.expired = expired;
+  const div = document.createElement("div");
+  div.className = "sanction-item" + (expired ? " expired" : "");
+  const icon = document.createElement("img");
+  icon.className = "sanction-icon";
+  const icons = [
+    "/assets/error.png",
+    "/assets/alert.png",
+    "/assets/update.png",
+    "/assets/unknown.png",
+  ];
+  icon.src = icons[Math.floor(Math.random() * icons.length)];
+  div.appendChild(icon);
+  const label = document.createElement("span");
+  const end = sanction.end
+    ? new Date(sanction.end).toLocaleString("fr-FR")
+    : "";
+  label.textContent = `${sanction.type}${end ? " (jusqu\u2019au " + end + ")" : ""}`;
+  div.appendChild(label);
+  div.addEventListener("click", () => openSanctionModal(sanction));
+  return div;
 }
 
 function openSanctionModal(s) {
-    document.getElementById('sanctionModalTitle').textContent = s.type;
-    document.getElementById('sanctionReason').textContent = s.reason || 'Aucune raison';
-    document.getElementById('sanctionDate').textContent = s.start ? new Date(s.start).toLocaleString('fr-FR') : '';
-    document.getElementById('sanctionAdmin').textContent = s.by || 'systauto';
-    const btn = document.getElementById('appealSanctionBtn');
-    btn.style.display = 'inline-block';
-    if (s.appeal_status === 'Pending') {
-        btn.disabled = true;
-        btn.style.cursor = 'not-allowed';
-        btn.onclick = null;
-    } else if (s.appeal_status === 'Approved') {
-        btn.style.display = 'none';
-    } else {
-        btn.disabled = false;
-        btn.style.cursor = 'pointer';
-        btn.onclick = () => appealSanction(s.id);
-    }
-    document.getElementById('sanctionDetailsModal').classList.add('active');
+  document.getElementById("sanctionModalTitle").textContent = s.type;
+  document.getElementById("sanctionReason").textContent =
+    s.reason || "Aucune raison";
+  document.getElementById("sanctionDate").textContent = s.start
+    ? new Date(s.start).toLocaleString("fr-FR")
+    : "";
+  document.getElementById("sanctionAdmin").textContent = s.by || "systauto";
+  const addInfo = document.getElementById("sanctionAdditionalInfo");
+  if (s.info) {
+    addInfo.textContent = s.info;
+  } else {
+    const links = [
+      "https://example.com/1",
+      "https://example.com/2",
+      "https://example.com/3",
+    ];
+    addInfo.innerHTML = `Aucune information supplémentaire. <img src="${links[Math.floor(Math.random() * links.length)]}" alt="">`;
+  }
+  const btn = document.getElementById("appealSanctionBtn");
+  btn.style.display = "inline-block";
+  if (s.expired) {
+    btn.style.display = "none";
+  } else if (s.appeal_status === "Pending") {
+    btn.disabled = true;
+    btn.style.cursor = "not-allowed";
+    btn.onclick = null;
+  } else if (s.appeal_status === "Approved") {
+    btn.style.display = "none";
+  } else {
+    btn.disabled = false;
+    btn.style.cursor = "pointer";
+    btn.onclick = () => appealSanction(s.id);
+  }
+  document.getElementById("sanctionDetailsModal").classList.add("active");
 }
+
+let pendingAppealId = null;
 
 async function appealSanction(id) {
-    const msg = prompt('Message de contestation:');
-    if (!msg) return;
-    const token = localStorage.getItem('token');
-    const res = await fetch(`${apiBaseURL}/user/sanctions/${id}/appeal`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-        body: JSON.stringify({ message: msg })
-    });
-    if (res.ok) {
-        showSuccessModal('Contestation envoyée', 'Votre demande sera traitée prochainement.');
-    } else {
-        showError('Erreur lors de la contestation');
-    }
-    document.getElementById('sanctionDetailsModal').classList.remove('active');
+  pendingAppealId = id;
+  document.getElementById("appealModal").classList.add("active");
 }
 
-document.getElementById('closeSanctionModal').addEventListener('click', () => {
-    document.getElementById('sanctionDetailsModal').classList.remove('active');
+document.getElementById("closeAppealModal").addEventListener("click", () => {
+  document.getElementById("appealModal").classList.remove("active");
+  pendingAppealId = null;
 });
 
-document.getElementById('closeSanctionDetailsBtn').addEventListener('click', () => {
-    document.getElementById('sanctionDetailsModal').classList.remove('active');
+document.getElementById("cancelAppeal").addEventListener("click", () => {
+  document.getElementById("appealModal").classList.remove("active");
+  pendingAppealId = null;
 });
 
+document.getElementById("sendAppeal").addEventListener("click", sendAppeal);
+
+async function sendAppeal() {
+  const msg = document.getElementById("appealMessage").value.trim();
+  if (!msg || !pendingAppealId) return;
+  const token = localStorage.getItem("token");
+  const res = await fetch(
+    `${apiBaseURL}/user/sanctions/${pendingAppealId}/appeal`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ message: msg }),
+    },
+  );
+  if (res.ok) {
+    showSuccessModal(
+      "Contestation envoyée",
+      "Votre demande sera traitée prochainement.",
+    );
+  } else {
+    showError("Erreur lors de la contestation");
+  }
+  document.getElementById("sanctionDetailsModal").classList.remove("active");
+  document.getElementById("appealModal").classList.remove("active");
+  pendingAppealId = null;
+}
+
+document.getElementById("closeSanctionModal").addEventListener("click", () => {
+  document.getElementById("sanctionDetailsModal").classList.remove("active");
+});
+
+document
+  .getElementById("closeSanctionDetailsBtn")
+  .addEventListener("click", () => {
+    document.getElementById("sanctionDetailsModal").classList.remove("active");
+  });

--- a/frontend/src/JS/admin/index.js
+++ b/frontend/src/JS/admin/index.js
@@ -1,388 +1,433 @@
 const BASE_API_URL = PANEL_CONFIG.API_BASE;
-const SECTION_IDS = { users: 'users-section', logs: 'logs-section', appeals: 'appeals-section' };
+const SECTION_IDS = {
+  users: "users-section",
+  logs: "logs-section",
+  appeals: "appeals-section",
+};
 let currentUserId = null;
 let currentPage = 1;
 let currentUserRole = null;
 let currentActivityPage = 1;
 let totalActivity = 0;
 
-const preloader = document.getElementById('preloader');
-const adminContent = document.getElementById('admin-content');
-const themeToggle = document.getElementById('theme-toggle');
-const adminAvatar = document.getElementById('admin-avatar');
+const preloader = document.getElementById("preloader");
+const adminContent = document.getElementById("admin-content");
+const themeToggle = document.getElementById("theme-toggle");
+const adminAvatar = document.getElementById("admin-avatar");
 
 function toggleTheme() {
-    document.body.classList.toggle('light-theme');
-    localStorage.setItem('theme', document.body.classList.contains('light-theme') ? 'light' : 'dark');
-    updateThemeIcon();
+  document.body.classList.toggle("light-theme");
+  localStorage.setItem(
+    "theme",
+    document.body.classList.contains("light-theme") ? "light" : "dark",
+  );
+  updateThemeIcon();
 }
 
 function updateThemeIcon() {
-    const icon = themeToggle.querySelector('i');
-    if (document.body.classList.contains('light-theme')) {
-    icon.classList.replace('fa-moon', 'fa-sun');
-    } else {
-    icon.classList.replace('fa-sun', 'fa-moon');
-    }
+  const icon = themeToggle.querySelector("i");
+  if (document.body.classList.contains("light-theme")) {
+    icon.classList.replace("fa-moon", "fa-sun");
+  } else {
+    icon.classList.replace("fa-sun", "fa-moon");
+  }
 }
 
-themeToggle.addEventListener('click', toggleTheme);
-if (localStorage.getItem('theme') === 'light') {
-    document.body.classList.add('light-theme');
+themeToggle.addEventListener("click", toggleTheme);
+if (localStorage.getItem("theme") === "light") {
+  document.body.classList.add("light-theme");
 }
 updateThemeIcon();
 
 function showToast(type, message) {
-    const toastContainer = document.getElementById('toast-container');
-    const toast = document.createElement('div');
-    toast.className = `toast ${type}`;
-    
-    const icons = {
-    success: 'check-circle',
-    error: 'exclamation-circle',
-    warning: 'exclamation-triangle',
-    info: 'info-circle'
-    };
-    
-    toast.innerHTML = `
+  const toastContainer = document.getElementById("toast-container");
+  const toast = document.createElement("div");
+  toast.className = `toast ${type}`;
+
+  const icons = {
+    success: "check-circle",
+    error: "exclamation-circle",
+    warning: "exclamation-triangle",
+    info: "info-circle",
+  };
+
+  toast.innerHTML = `
     <i class="fas fa-${icons[type]} toast-icon"></i>
     <span>${message}</span>
     <button class="toast-close">&times;</button>
     `;
-    
-    toastContainer.appendChild(toast);
-    
+
+  toastContainer.appendChild(toast);
+
+  setTimeout(() => {
+    toast.classList.add("show");
+  }, 100);
+
+  setTimeout(() => {
+    toast.classList.remove("show");
     setTimeout(() => {
-    toast.classList.add('show');
-    }, 100);
-    
-    setTimeout(() => {
-    toast.classList.remove('show');
-    setTimeout(() => {
-        toast.remove();
+      toast.remove();
     }, 300);
-    }, 5000);
-    
-    toast.querySelector('.toast-close').addEventListener('click', () => {
-    toast.classList.remove('show');
+  }, 5000);
+
+  toast.querySelector(".toast-close").addEventListener("click", () => {
+    toast.classList.remove("show");
     setTimeout(() => {
-        toast.remove();
+      toast.remove();
     }, 300);
-    });
+  });
 }
 
 async function checkAdminPermissions() {
-    try {
-    const token = localStorage.getItem('token');
+  try {
+    const token = localStorage.getItem("token");
     if (!token) {
-        throw new Error('No token found');
+      throw new Error("No token found");
     }
 
     const response = await fetch(`${BASE_API_URL}/user/me`, {
-        headers: {
-        'Authorization': `Bearer ${token}`
-        }
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     });
-    
+
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
-    
+
     const data = await response.json();
-    if (!data.success || !data.user || data.user.role !== 'Admin') {
-        throw new Error('User is not admin');
+    if (!data.success || !data.user || data.user.role !== "Admin") {
+      throw new Error("User is not admin");
     }
 
     const user = data.user;
     currentUserRole = user.role;
-    adminAvatar.src = user.avatar_url ? `${user.avatar_url}` : '/assets/account.png';
-    
-    if (user.role === 'Moderator') {
-        window.location.href = '/moderator';
-        return false;
+    adminAvatar.src = user.avatar_url
+      ? `${user.avatar_url}`
+      : "/assets/account.png";
+
+    if (user.role === "Moderator") {
+      window.location.href = "/moderator";
+      return false;
     }
 
     return true;
-    } catch (error) {
-    console.error('Permission check failed:', error);
+  } catch (error) {
+    console.error("Permission check failed:", error);
     return false;
-    }
+  }
 }
 
-async function fetchUsers(search = '', page = 1) {
-    showLoadingSkeleton('users');
-    
-    try {
-    const token = localStorage.getItem('token');
-    const response = await fetch(`${BASE_API_URL}/admin/users?search=${encodeURIComponent(search)}&page=${page}`, {
+async function fetchUsers(search = "", page = 1) {
+  showLoadingSkeleton("users");
+
+  try {
+    const token = localStorage.getItem("token");
+    const response = await fetch(
+      `${BASE_API_URL}/admin/users?search=${encodeURIComponent(search)}&page=${page}`,
+      {
         headers: {
-        'Authorization': `Bearer ${token}`
-        }
-    });
-    
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
-    
+
     const data = await response.json();
     return data;
-    } catch (error) {
-    showToast('error', `Erreur lors du chargement des utilisateurs: ${error.message}`);
-    console.error('Error fetching users:', error);
+  } catch (error) {
+    showToast(
+      "error",
+      `Erreur lors du chargement des utilisateurs: ${error.message}`,
+    );
+    console.error("Error fetching users:", error);
     return { users: [], total: 0 };
-    }
+  }
 }
 
 async function fetchUserDetails(userId) {
-    try {
-    const token = localStorage.getItem('token');
+  try {
+    const token = localStorage.getItem("token");
     const response = await fetch(`${BASE_API_URL}/admin/users/${userId}`, {
-        headers: {
-        'Authorization': `Bearer ${token}`
-        }
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     });
-    
+
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
-    
+
     return await response.json();
-    } catch (error) {
-    showToast('error', `Erreur lors du chargement des détails: ${error.message}`);
-    console.error('Error fetching user details:', error);
+  } catch (error) {
+    showToast(
+      "error",
+      `Erreur lors du chargement des détails: ${error.message}`,
+    );
+    console.error("Error fetching user details:", error);
     return null;
-    }
+  }
 }
 
 async function fetchUserActivity(userId, page = 1) {
-    try {
-    const token = localStorage.getItem('token');
-    const response = await fetch(`${BASE_API_URL}/admin/users/${userId}/activity?page=${page}`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-    });
+  try {
+    const token = localStorage.getItem("token");
+    const response = await fetch(
+      `${BASE_API_URL}/admin/users/${userId}/activity?page=${page}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
     return await response.json();
-    } catch (error) {
-    showToast('error', `Erreur lors du chargement de l'activité: ${error.message}`);
-    console.error('Error fetching user activity:', error);
+  } catch (error) {
+    showToast(
+      "error",
+      `Erreur lors du chargement de l'activité: ${error.message}`,
+    );
+    console.error("Error fetching user activity:", error);
     return { logs: [], total: 0 };
-    }
+  }
 }
 
 async function fetchUserTools(userId) {
-    try {
-    const token = localStorage.getItem('token');
-    const response = await fetch(`${BASE_API_URL}/admin/users/${userId}/tools`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-    });
+  try {
+    const token = localStorage.getItem("token");
+    const response = await fetch(
+      `${BASE_API_URL}/admin/users/${userId}/tools`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
     return await response.json();
-    } catch (error) {
-    showToast('error', `Erreur lors du chargement des outils: ${error.message}`);
-    console.error('Error fetching user tools:', error);
+  } catch (error) {
+    showToast(
+      "error",
+      `Erreur lors du chargement des outils: ${error.message}`,
+    );
+    console.error("Error fetching user tools:", error);
     return { tools: [] };
-    }
+  }
 }
 
 async function fetchBanInfo(userId) {
-    try {
-    const token = localStorage.getItem('token');
+  try {
+    const token = localStorage.getItem("token");
     const response = await fetch(`${BASE_API_URL}/admin/users/${userId}/ban`, {
-        headers: { 'Authorization': `Bearer ${token}` }
+      headers: { Authorization: `Bearer ${token}` },
     });
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
     return await response.json();
-    } catch (error) {
-    showToast('error', `Erreur lors du chargement de la raison: ${error.message}`);
-    console.error('Error fetching ban info:', error);
+  } catch (error) {
+    showToast(
+      "error",
+      `Erreur lors du chargement de la raison: ${error.message}`,
+    );
+    console.error("Error fetching ban info:", error);
     return null;
-    }
+  }
 }
 
 async function fetchSystemLogs(page = 1) {
-    showLoadingSkeleton('logs');
-    
-    try {
-    const token = localStorage.getItem('token');
+  showLoadingSkeleton("logs");
+
+  try {
+    const token = localStorage.getItem("token");
     const response = await fetch(`${BASE_API_URL}/admin/logs?page=${page}`, {
-        headers: {
-        'Authorization': `Bearer ${token}`
-        }
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     });
-    
+
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
-    
+
     return await response.json();
-    } catch (error) {
-    showToast('error', `Erreur lors du chargement des logs: ${error.message}`);
-    console.error('Error fetching system logs:', error);
+  } catch (error) {
+    showToast("error", `Erreur lors du chargement des logs: ${error.message}`);
+    console.error("Error fetching system logs:", error);
     return { logs: [], total: 0 };
-    }
+  }
 }
 
 async function fetchAppeals(page = 1) {
-    try {
-        const token = localStorage.getItem('token');
-        const res = await fetch(`${BASE_API_URL}/admin/appeals?page=${page}`, { headers: { 'Authorization': `Bearer ${token}` } });
-        if (!res.ok) throw new Error(res.status);
-        return await res.json();
-    } catch (e) {
-        showToast('error', `Erreur chargement contestations: ${e}`);
-        return { appeals: [], total: 0 };
-    }
+  try {
+    const token = localStorage.getItem("token");
+    const res = await fetch(`${BASE_API_URL}/admin/appeals?page=${page}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(res.status);
+    return await res.json();
+  } catch (e) {
+    showToast("error", `Erreur chargement contestations: ${e}`);
+    return { appeals: [], total: 0 };
+  }
 }
 
 async function fetchStats() {
-    showLoadingSkeleton('stats');
-    
-    try {
-    const token = localStorage.getItem('token');
+  showLoadingSkeleton("stats");
+
+  try {
+    const token = localStorage.getItem("token");
     const response = await fetch(`${BASE_API_URL}/admin/stats`, {
-        headers: {
-        'Authorization': `Bearer ${token}`
-        }
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     });
-    
+
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
-    
+
     return await response.json();
-    } catch (error) {
-    showToast('error', `Erreur lors du chargement des statistiques: ${error.message}`);
-    console.error('Error fetching stats:', error);
+  } catch (error) {
+    showToast(
+      "error",
+      `Erreur lors du chargement des statistiques: ${error.message}`,
+    );
+    console.error("Error fetching stats:", error);
     return null;
-    }
+  }
 }
 
 async function updateUser(userId, data) {
-    try {
-    const token = localStorage.getItem('token');
+  try {
+    const token = localStorage.getItem("token");
     const response = await fetch(`${BASE_API_URL}/admin/users/${userId}`, {
-        method: 'PUT',
-        headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(data)
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
     });
-    
+
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
-    
+
     const result = await response.json();
-    showToast('success', 'Utilisateur mis à jour avec succès');
+    showToast("success", "Utilisateur mis à jour avec succès");
     return result;
-    } catch (error) {
-    showToast('error', `Erreur lors de la mise à jour: ${error.message}`);
-    console.error('Error updating user:', error);
+  } catch (error) {
+    showToast("error", `Erreur lors de la mise à jour: ${error.message}`);
+    console.error("Error updating user:", error);
     return null;
-    }
+  }
 }
 
 async function banUser(userId, reason) {
-    try {
-    const token = localStorage.getItem('token');
+  try {
+    const token = localStorage.getItem("token");
     const response = await fetch(`${BASE_API_URL}/admin/users/${userId}/ban`, {
-        method: 'POST',
-        headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ reason, duration_hours: parseInt(document.getElementById('ban-duration').value, 10) || 0 })
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        reason,
+        duration_hours:
+          parseInt(document.getElementById("ban-duration").value, 10) || 0,
+      }),
     });
-    
+
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
-    
+
     const result = await response.json();
-    showToast('success', 'Utilisateur banni avec succès');
+    showToast("success", "Utilisateur banni avec succès");
     return result;
-    } catch (error) {
-    showToast('error', `Erreur lors du ban: ${error.message}`);
-    console.error('Error banning user:', error);
+  } catch (error) {
+    showToast("error", `Erreur lors du ban: ${error.message}`);
+    console.error("Error banning user:", error);
     return null;
-    }
+  }
 }
 
 async function unbanUser(userId) {
-    try {
-    const token = localStorage.getItem('token');
-    const response = await fetch(`${BASE_API_URL}/admin/users/${userId}/unban`, {
-        method: 'POST',
+  try {
+    const token = localStorage.getItem("token");
+    const response = await fetch(
+      `${BASE_API_URL}/admin/users/${userId}/unban`,
+      {
+        method: "POST",
         headers: {
-        'Authorization': `Bearer ${token}`
-        }
-    });
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
 
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
 
     const result = await response.json();
-    showToast('success', 'Utilisateur débanni avec succès');
+    showToast("success", "Utilisateur débanni avec succès");
     return result;
-    } catch (error) {
-    showToast('error', `Erreur lors du débannissement: ${error.message}`);
-    console.error('Error unbanning user:', error);
+  } catch (error) {
+    showToast("error", `Erreur lors du débannissement: ${error.message}`);
+    console.error("Error unbanning user:", error);
     return null;
-    }
+  }
 }
 
 async function reviewAppeal(id, approve, message) {
-    try {
-        const token = localStorage.getItem('token');
-        const response = await fetch(`${BASE_API_URL}/admin/appeals/${id}`, {
-            method: 'POST',
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ approve, message })
-        });
-        if (!response.ok) throw new Error(response.status);
-        showToast('success', 'Contestation mise à jour');
-        return true;
-    } catch (e) {
-        showToast('error', `Erreur: ${e}`);
-        return false;
-    }
+  try {
+    const token = localStorage.getItem("token");
+    const response = await fetch(`${BASE_API_URL}/admin/appeals/${id}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ approve, message }),
+    });
+    if (!response.ok) throw new Error(response.status);
+    showToast("success", "Contestation mise à jour");
+    return true;
+  } catch (e) {
+    showToast("error", `Erreur: ${e}`);
+    return false;
+  }
 }
 
 async function clearLogs() {
-    if (!confirm('Supprimer tous les logs ?')) return;
-    try {
-    const token = localStorage.getItem('token');
+  if (!confirm("Supprimer tous les logs ?")) return;
+  try {
+    const token = localStorage.getItem("token");
     const response = await fetch(`${BASE_API_URL}/admin/logs/clear`, {
-        method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}` }
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
     });
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
+      throw new Error(`HTTP error: ${response.status}`);
     }
-    showToast('success', 'Logs supprimés');
+    showToast("success", "Logs supprimés");
     loadSystemLogs();
-    } catch (error) {
-    showToast('error', `Erreur lors de la suppression: ${error.message}`);
-    console.error('Error clearing logs:', error);
-    }
+  } catch (error) {
+    showToast("error", `Erreur lors de la suppression: ${error.message}`);
+    console.error("Error clearing logs:", error);
+  }
 }
 
 function showLoadingSkeleton(type) {
-    if (type === 'stats') {
-    const statsCards = document.querySelector('.stats-cards');
+  if (type === "stats") {
+    const statsCards = document.querySelector(".stats-cards");
     if (statsCards) {
-        statsCards.innerHTML = `
+      statsCards.innerHTML = `
         <div class="stat-card">
             <h3 class="skeleton skeleton-title"></h3>
             <div class="value skeleton skeleton-value"></div>
@@ -405,12 +450,12 @@ function showLoadingSkeleton(type) {
         </div>
         `;
     }
-    } else if (type === 'users') {
-    const tbody = document.getElementById('users-table-body');
+  } else if (type === "users") {
+    const tbody = document.getElementById("users-table-body");
     if (tbody) {
-        tbody.innerHTML = '';
-        for (let i = 0; i < 5; i++) {
-        const row = document.createElement('tr');
+      tbody.innerHTML = "";
+      for (let i = 0; i < 5; i++) {
+        const row = document.createElement("tr");
         row.innerHTML = `
             <td>
             <div class="user-cell">
@@ -433,14 +478,14 @@ function showLoadingSkeleton(type) {
             </td>
         `;
         tbody.appendChild(row);
-        }
+      }
     }
-    } else if (type === 'logs') {
-    const tbody = document.getElementById('logs-table-body');
+  } else if (type === "logs") {
+    const tbody = document.getElementById("logs-table-body");
     if (tbody) {
-        tbody.innerHTML = '';
-        for (let i = 0; i < 5; i++) {
-        const row = document.createElement('tr');
+      tbody.innerHTML = "";
+      for (let i = 0; i < 5; i++) {
+        const row = document.createElement("tr");
         row.innerHTML = `
             <td><div class="skeleton skeleton-text" style="width: 120px;"></div></td>
             <td>
@@ -454,14 +499,14 @@ function showLoadingSkeleton(type) {
             <td><div class="skeleton skeleton-text" style="width: 100px;"></div></td>
         `;
         tbody.appendChild(row);
-        }
+      }
     }
-    }
+  }
 }
 
 function renderStats(stats) {
-    const statsContainer = document.createElement('div');
-    statsContainer.innerHTML = `
+  const statsContainer = document.createElement("div");
+  statsContainer.innerHTML = `
     <h2 class="section-title">
         <i class="fas fa-chart-line"></i>
         Statistiques <span>globales</span>
@@ -470,24 +515,24 @@ function renderStats(stats) {
         <div class="stat-card">
         <h3><i class="fas fa-users"></i> Utilisateurs totaux</h3>
         <div class="value">${stats.totalUsers.toLocaleString()}</div>
-        <div class="change ${stats.userGrowth >= 0 ? 'positive' : 'negative'}">
-            <i class="fas fa-${stats.userGrowth >= 0 ? 'arrow-up' : 'arrow-down'}"></i>
+        <div class="change ${stats.userGrowth >= 0 ? "positive" : "negative"}">
+            <i class="fas fa-${stats.userGrowth >= 0 ? "arrow-up" : "arrow-down"}"></i>
             ${Math.abs(stats.userGrowth)}% ce mois-ci
         </div>
         </div>
         <div class="stat-card">
         <h3><i class="fas fa-user-plus"></i> Nouveaux utilisateurs</h3>
         <div class="value">${stats.newUsers.toLocaleString()}</div>
-        <div class="change ${stats.newUsersGrowth >= 0 ? 'positive' : 'negative'}">
-            <i class="fas fa-${stats.newUsersGrowth >= 0 ? 'arrow-up' : 'arrow-down'}"></i>
+        <div class="change ${stats.newUsersGrowth >= 0 ? "positive" : "negative"}">
+            <i class="fas fa-${stats.newUsersGrowth >= 0 ? "arrow-up" : "arrow-down"}"></i>
             ${Math.abs(stats.newUsersGrowth)}% cette semaine
         </div>
         </div>
         <div class="stat-card">
         <h3><i class="fas fa-user-slash"></i> Utilisateurs bannis</h3>
         <div class="value">${stats.bannedUsers.toLocaleString()}</div>
-        <div class="change ${stats.bannedUsersChange >= 0 ? 'positive' : 'negative'}">
-            <i class="fas fa-${stats.bannedUsersChange >= 0 ? 'arrow-up' : 'arrow-down'}"></i>
+        <div class="change ${stats.bannedUsersChange >= 0 ? "positive" : "negative"}">
+            <i class="fas fa-${stats.bannedUsersChange >= 0 ? "arrow-up" : "arrow-down"}"></i>
             ${Math.abs(stats.bannedUsersChange)}% ce mois-ci
         </div>
         </div>
@@ -500,12 +545,12 @@ function renderStats(stats) {
         </div>
     </div>
     `;
-    return statsContainer;
+  return statsContainer;
 }
 
 function renderUsersTable(users, page = 1, total = 0) {
-    const container = document.createElement('div');
-    container.innerHTML = `
+  const container = document.createElement("div");
+  container.innerHTML = `
     <h2 class="section-title">
     <i class="fas fa-users"></i>
     Gestion des <span>utilisateurs</span>
@@ -536,23 +581,28 @@ function renderUsersTable(users, page = 1, total = 0) {
     <div class="pagination" id="users-pagination"></div>
     </div>
     `;
-    
-    const tbody = container.querySelector('#users-table-body');
-    
-    users.forEach(user => {
-    const tr = document.createElement('tr');
+
+  const tbody = container.querySelector("#users-table-body");
+
+  users.forEach((user) => {
+    const tr = document.createElement("tr");
     tr.innerHTML = `
     <td>
     <div class="user-cell">
-        <img src="${user.avatar_url || '/assets/account.png'}" alt="${user.username}" class="user-avatar-sm">
+        <img src="${user.avatar_url || "/assets/account.png"}" alt="${user.username}" class="user-avatar-sm">
         <div class="user-info">
         <span class="user-name" style="
-        ${user.role === 'admin' ? 'color:#ef4444;font-weight:600;' : 
-        user.role === 'moderator' ? 'color:#f59e0b;font-weight:600;' : ''}
+        ${
+          user.role === "admin"
+            ? "color:#ef4444;font-weight:600;"
+            : user.role === "moderator"
+              ? "color:#f59e0b;font-weight:600;"
+              : ""
+        }
         ">
         ${user.username}
-        ${user.role === 'admin' ? ' (Admin)' : user.role === 'moderator' ? ' (Mod)' : ''}
-        ${user.is_verified === true ? '<img src="/assets/verified.png" alt="Vérifié" title="Compte vérifié" style="width: 15px;height: 15px;vertical-align:middle;margin-bottom: 2px;">' : ''}
+        ${user.role === "admin" ? " (Admin)" : user.role === "moderator" ? " (Mod)" : ""}
+        ${user.is_verified === true ? '<img src="/assets/verified.png" alt="Vérifié" title="Compte vérifié" style="width: 15px;height: 15px;vertical-align:middle;margin-bottom: 2px;">' : ""}
         </span>
         <span class="user-email">@${user.username}</span>
         </div>
@@ -560,27 +610,47 @@ function renderUsersTable(users, page = 1, total = 0) {
     </td>
     <td>${user.email}</td>
     <td>${new Date(user.created_at).toLocaleDateString()}</td>
-    <td>${user.two_factor_enabled ? 'Oui' : 'Non'}</td>
+    <td>${user.two_factor_enabled ? "Oui" : "Non"}</td>
     <td>
     <span class="status-badge 
-        ${user.status === 'Good' ? 'status-active' : 
-        user.status === 'Limited' ? 'status-pending' : 
-        user.status === 'Very Limited' ? 'status-pending' : 
-        user.status === 'At Risk' ? 'status-pending' : 
-        user.status === 'Banned' ? 'status-banned' : 'status-pending'}">
+        ${
+          user.status === "Good"
+            ? "status-active"
+            : user.status === "Limited"
+              ? "status-pending"
+              : user.status === "Very Limited"
+                ? "status-pending"
+                : user.status === "At Risk"
+                  ? "status-pending"
+                  : user.status === "Banned"
+                    ? "status-banned"
+                    : "status-pending"
+        }">
         <i class="fas fa-${
-        user.status === 'Good' ? 'check-circle' : 
-        user.status === 'Limited' ? 'exclamation-triangle' : 
-        user.status === 'Very Limited' ? 'exclamation-triangle' : 
-        user.status === 'At Risk' ? 'exclamation-circle' : 
-        user.status === 'Banned' ? 'ban' : 'clock'
+          user.status === "Good"
+            ? "check-circle"
+            : user.status === "Limited"
+              ? "exclamation-triangle"
+              : user.status === "Very Limited"
+                ? "exclamation-triangle"
+                : user.status === "At Risk"
+                  ? "exclamation-circle"
+                  : user.status === "Banned"
+                    ? "ban"
+                    : "clock"
         }"></i>
         ${
-        user.status === 'Good' ? 'Actif' : 
-        user.status === 'Limited' ? 'Limité' : 
-        user.status === 'Very Limited' ? 'Très limité' : 
-        user.status === 'At Risk' ? 'À risque' : 
-        user.status === 'Banned' ? 'Banni' : 'En attente'
+          user.status === "Good"
+            ? "Actif"
+            : user.status === "Limited"
+              ? "Limité"
+              : user.status === "Very Limited"
+                ? "Très limité"
+                : user.status === "At Risk"
+                  ? "À risque"
+                  : user.status === "Banned"
+                    ? "Banni"
+                    : "En attente"
         }
     </span>
     </td>
@@ -591,63 +661,72 @@ function renderUsersTable(users, page = 1, total = 0) {
     <button class="action-btn edit" data-user-id="${user.user_id}" title="Modifier">
         <i class="fas fa-edit"></i>
     </button>
-    ${user.status === 'Banned' ? `
+    ${
+      user.status === "Banned"
+        ? `
     <button class="action-btn delete" data-user-id="${user.user_id}" data-action="unban" title="Débannir">
         <i class="fas fa-unlock"></i>
     </button>
-    ` : `
+    `
+        : `
     <button class="action-btn delete" data-user-id="${user.user_id}" data-action="ban" title="Bannir">
         <i class="fas fa-ban"></i>
     </button>
-    `}
+    `
+    }
     </td>
     `;
     tbody.appendChild(tr);
-    });
-    
-    container.querySelectorAll('.action-btn.view, .action-btn.edit').forEach(btn => {
-    btn.addEventListener('click', async () => {
-    const userId = btn.getAttribute('data-user-id');
-    openUserModal(userId);
-    });
-    });
-    
-    container.querySelectorAll('.action-btn.delete').forEach(btn => {
-    btn.addEventListener('click', () => {
-    currentUserId = btn.getAttribute('data-user-id');
-    const action = btn.getAttribute('data-action');
-    openBanModal(action === 'unban');
-    });
-    });
-    
-    const searchInput = container.querySelector('#user-search');
-    let searchTimeout;
+  });
 
-    searchInput.addEventListener('input', () => {
+  container
+    .querySelectorAll(".action-btn.view, .action-btn.edit")
+    .forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        const userId = btn.getAttribute("data-user-id");
+        openUserModal(userId);
+      });
+    });
+
+  container.querySelectorAll(".action-btn.delete").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      currentUserId = btn.getAttribute("data-user-id");
+      const action = btn.getAttribute("data-action");
+      openBanModal(action === "unban");
+    });
+  });
+
+  const searchInput = container.querySelector("#user-search");
+  let searchTimeout;
+
+  searchInput.addEventListener("input", () => {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(() => {
-    loadUsers(searchInput.value, 1);
+      loadUsers(searchInput.value, 1);
     }, 500);
-    });
+  });
 
-    const pag = container.querySelector('#users-pagination');
-    const maxPage = Math.max(1, Math.ceil(total / 10));
-    pag.innerHTML = `
-    <button class="page-btn" ${page<=1?'disabled':''} data-page="${page-1}"><i class="fas fa-chevron-left"></i></button>
+  const pag = container.querySelector("#users-pagination");
+  const maxPage = Math.max(1, Math.ceil(total / 10));
+  pag.innerHTML = `
+    <button class="page-btn" ${page <= 1 ? "disabled" : ""} data-page="${page - 1}"><i class="fas fa-chevron-left"></i></button>
     <span class="page-info">Page ${page}/${maxPage}</span>
-    <button class="page-btn" ${page>=maxPage?'disabled':''} data-page="${page+1}"><i class="fas fa-chevron-right"></i></button>`;
-    pag.querySelectorAll('button').forEach(btn=>{
-    btn.addEventListener('click',()=>{
-        const p=parseInt(btn.getAttribute('data-page')); if(p>=1&&p<=maxPage){ loadUsers(searchInput.value,p); }
+    <button class="page-btn" ${page >= maxPage ? "disabled" : ""} data-page="${page + 1}"><i class="fas fa-chevron-right"></i></button>`;
+  pag.querySelectorAll("button").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const p = parseInt(btn.getAttribute("data-page"));
+      if (p >= 1 && p <= maxPage) {
+        loadUsers(searchInput.value, p);
+      }
     });
-    });
-    
-    return container;
+  });
+
+  return container;
 }
 
 function renderSystemLogs(logs, page = 1, total = 0) {
-    const container = document.createElement('div');
-    container.innerHTML = `
+  const container = document.createElement("div");
+  container.innerHTML = `
     <h2 class="section-title">
         <i class="fas fa-clipboard-list"></i>
         Logs <span>système</span>
@@ -680,58 +759,67 @@ function renderSystemLogs(logs, page = 1, total = 0) {
         <div class="pagination" id="logs-pagination"></div>
     </div>
     `;
-    
-    const tbody = container.querySelector('#logs-table-body');
-    
-    logs.forEach(log => {
-    const tr = document.createElement('tr');
+
+  const tbody = container.querySelector("#logs-table-body");
+
+  logs.forEach((log) => {
+    const tr = document.createElement("tr");
     tr.innerHTML = `
         <td>${new Date(log.timestamp).toLocaleString()}</td>
         <td>
-        ${log.user ? `
+        ${
+          log.user
+            ? `
         <div class="user-cell">
-            <img src="${log.user.avatar || '/assets/account.png'}" alt="${log.user.username}" class="user-avatar-sm">
+            <img src="${log.user.avatar || "/assets/account.png"}" alt="${log.user.username}" class="user-avatar-sm">
             <span class="user-name">${log.user.username}</span>
         </div>
-        ` : 'Système'}
+        `
+            : "Système"
+        }
         </td>
         <td>${log.action}</td>
-        <td>${log.details || ''}</td>
-        <td>${log.ip || 'N/A'}</td>
+        <td>${log.details || ""}</td>
+        <td>${log.ip || "N/A"}</td>
     `;
     tbody.appendChild(tr);
-    });
-    
-    const searchInput = container.querySelector('#logs-search');
-    let searchTimeout;
+  });
 
-    searchInput.addEventListener('input', () => {
+  const searchInput = container.querySelector("#logs-search");
+  let searchTimeout;
+
+  searchInput.addEventListener("input", () => {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(() => {
-        loadSystemLogs(1);
+      loadSystemLogs(1);
     }, 500);
-    });
+  });
 
-    container.querySelector('#clear-logs-btn').addEventListener('click', clearLogs);
+  container
+    .querySelector("#clear-logs-btn")
+    .addEventListener("click", clearLogs);
 
-    const pag = container.querySelector('#logs-pagination');
-    const maxPage = Math.max(1, Math.ceil(total / 10));
-    pag.innerHTML = `
-    <button class="page-btn" ${page<=1?'disabled':''} data-page="${page-1}"><i class="fas fa-chevron-left"></i></button>
+  const pag = container.querySelector("#logs-pagination");
+  const maxPage = Math.max(1, Math.ceil(total / 10));
+  pag.innerHTML = `
+    <button class="page-btn" ${page <= 1 ? "disabled" : ""} data-page="${page - 1}"><i class="fas fa-chevron-left"></i></button>
     <span class="page-info">Page ${page}/${maxPage}</span>
-    <button class="page-btn" ${page>=maxPage?'disabled':''} data-page="${page+1}"><i class="fas fa-chevron-right"></i></button>`;
-    pag.querySelectorAll('button').forEach(btn=>{
-    btn.addEventListener('click',()=>{
-        const p=parseInt(btn.getAttribute('data-page')); if(p>=1&&p<=maxPage){ loadSystemLogs(p); }
+    <button class="page-btn" ${page >= maxPage ? "disabled" : ""} data-page="${page + 1}"><i class="fas fa-chevron-right"></i></button>`;
+  pag.querySelectorAll("button").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const p = parseInt(btn.getAttribute("data-page"));
+      if (p >= 1 && p <= maxPage) {
+        loadSystemLogs(p);
+      }
     });
-    });
-    
-    return container;
+  });
+
+  return container;
 }
 
 function renderAppealsTable(appeals, page = 1, total = 0) {
-    const container = document.createElement('div');
-    container.innerHTML = `
+  const container = document.createElement("div");
+  container.innerHTML = `
     <h2 class="section-title">
         <i class="fas fa-gavel"></i> Contestations
     </h2>
@@ -742,101 +830,111 @@ function renderAppealsTable(appeals, page = 1, total = 0) {
         </table>
         <div class="pagination" id="appeals-pagination"></div>
     </div>`;
-    const body = container.querySelector('#appeals-body');
-    appeals.forEach(ap => {
-        const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${ap.user_id}</td><td>${ap.message}</td><td>${ap.status}</td><td><button class="btn btn-success" data-action="approve" data-id="${ap.appeal_id}">Accepter</button> <button class="btn btn-danger" data-action="reject" data-id="${ap.appeal_id}">Refuser</button></td>`;
-        body.appendChild(tr);
+  const body = container.querySelector("#appeals-body");
+  appeals.forEach((ap) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `<td>${ap.user_id}</td><td>${ap.message}</td><td>${ap.status}</td><td><button class="icon-btn" data-action="approve" data-id="${ap.appeal_id}"><i class="fas fa-check"></i></button> <button class="icon-btn" data-action="reject" data-id="${ap.appeal_id}"><i class="fas fa-times"></i></button></td>`;
+    body.appendChild(tr);
+  });
+  container.querySelectorAll("button[data-action]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const id = btn.getAttribute("data-id");
+      const approve = btn.getAttribute("data-action") === "approve";
+      openAppealModal(id, approve, page);
     });
-    container.querySelectorAll('button[data-action]').forEach(btn=>{
-        btn.addEventListener('click',()=>{
-            const id=btn.getAttribute('data-id');
-            const approve=btn.getAttribute('data-action')==='approve';
-            const msg=prompt('Message pour l\'utilisateur:')||'';
-            reviewAppeal(id,approve,msg).then(ok=>{if(ok) loadAppeals(page);});
-        });
-    });
-    const pag = container.querySelector('#appeals-pagination');
-    const maxPage = Math.max(1, Math.ceil(total/10));
-    pag.innerHTML = `<button class="page-btn" ${page<=1?'disabled':''} data-p="${page-1}"><i class="fas fa-chevron-left"></i></button><span class="page-info">Page ${page}/${maxPage}</span><button class="page-btn" ${page>=maxPage?'disabled':''} data-p="${page+1}"><i class="fas fa-chevron-right"></i></button>`;
-    pag.querySelectorAll('button').forEach(b=>b.addEventListener('click',()=>{const p=parseInt(b.dataset.p);if(p>=1&&p<=maxPage)loadAppeals(p);}));
-    return container;
+  });
+  const pag = container.querySelector("#appeals-pagination");
+  const maxPage = Math.max(1, Math.ceil(total / 10));
+  pag.innerHTML = `<button class="page-btn" ${page <= 1 ? "disabled" : ""} data-p="${page - 1}"><i class="fas fa-chevron-left"></i></button><span class="page-info">Page ${page}/${maxPage}</span><button class="page-btn" ${page >= maxPage ? "disabled" : ""} data-p="${page + 1}"><i class="fas fa-chevron-right"></i></button>`;
+  pag.querySelectorAll("button").forEach((b) =>
+    b.addEventListener("click", () => {
+      const p = parseInt(b.dataset.p);
+      if (p >= 1 && p <= maxPage) loadAppeals(p);
+    }),
+  );
+  return container;
 }
 
 function renderUserActivity(logs, page = 1, total = 0) {
-    const container = document.createElement('div');
-    if (!logs.length) {
-    container.innerHTML = '<p>Aucune activité récente.</p>';
+  const container = document.createElement("div");
+  if (!logs.length) {
+    container.innerHTML = "<p>Aucune activité récente.</p>";
     return container;
-    }
-    const list = document.createElement('ul');
-    list.className = 'activity-list';
-    logs.forEach(log => {
-    const li = document.createElement('li');
-    li.className = 'activity-item';
+  }
+  const list = document.createElement("ul");
+  list.className = "activity-list";
+  logs.forEach((log) => {
+    const li = document.createElement("li");
+    li.className = "activity-item";
     li.innerHTML = `
         <span class="activity-date">${new Date(log.timestamp).toLocaleString()}</span>
-        <span class="activity-action">${log.action}${log.message ? ' - ' + log.message : ''}</span>
-        <span class="${log.success ? 'activity-success' : 'activity-fail'}">
-        <i class="fas fa-${log.success ? 'check-circle' : 'times-circle'}"></i>
+        <span class="activity-action">${log.action}${log.message ? " - " + log.message : ""}</span>
+        <span class="${log.success ? "activity-success" : "activity-fail"}">
+        <i class="fas fa-${log.success ? "check-circle" : "times-circle"}"></i>
         </span>`;
     list.appendChild(li);
-    });
-    container.appendChild(list);
-    const maxPage = Math.max(1, Math.ceil(total / 10));
-    const pag = document.createElement('div');
-    pag.className = 'pagination';
-    pag.innerHTML = `
-    <button class="page-btn" ${page<=1?'disabled':''} data-page="${page-1}"><i class="fas fa-chevron-left"></i></button>
+  });
+  container.appendChild(list);
+  const maxPage = Math.max(1, Math.ceil(total / 10));
+  const pag = document.createElement("div");
+  pag.className = "pagination";
+  pag.innerHTML = `
+    <button class="page-btn" ${page <= 1 ? "disabled" : ""} data-page="${page - 1}"><i class="fas fa-chevron-left"></i></button>
     <span class="page-info">Page ${page}/${maxPage}</span>
-    <button class="page-btn" ${page>=maxPage?'disabled':''} data-page="${page+1}"><i class="fas fa-chevron-right"></i></button>`;
-    pag.querySelectorAll('button').forEach(btn=>{
-    btn.addEventListener('click',()=>{
-        const p=parseInt(btn.getAttribute('data-page')); if(p>=1&&p<=maxPage){ loadActivityPage(p); }
+    <button class="page-btn" ${page >= maxPage ? "disabled" : ""} data-page="${page + 1}"><i class="fas fa-chevron-right"></i></button>`;
+  pag.querySelectorAll("button").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const p = parseInt(btn.getAttribute("data-page"));
+      if (p >= 1 && p <= maxPage) {
+        loadActivityPage(p);
+      }
     });
-    });
-    container.appendChild(pag);
-    return container;
+  });
+  container.appendChild(pag);
+  return container;
 }
 
 async function loadActivityPage(page) {
-    if (!currentUserId) return;
-    const activityTab = document.getElementById('activity-tab');
-    activityTab.innerHTML = '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
-    const data = await fetchUserActivity(currentUserId, page);
-    currentActivityPage = page;
-    totalActivity = data.total || 0;
-    activityTab.innerHTML = '';
-    activityTab.appendChild(renderUserActivity(data.logs || [], page, totalActivity));
+  if (!currentUserId) return;
+  const activityTab = document.getElementById("activity-tab");
+  activityTab.innerHTML =
+    '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
+  const data = await fetchUserActivity(currentUserId, page);
+  currentActivityPage = page;
+  totalActivity = data.total || 0;
+  activityTab.innerHTML = "";
+  activityTab.appendChild(
+    renderUserActivity(data.logs || [], page, totalActivity),
+  );
 }
 
 function renderUserTools(tools) {
-    const container = document.createElement('div');
-    if (!tools.length) {
-    container.innerHTML = '<p>Aucun outil.</p>';
+  const container = document.createElement("div");
+  if (!tools.length) {
+    container.innerHTML = "<p>Aucun outil.</p>";
     return container;
-    }
-    const grid = document.createElement('div');
-    grid.className = 'admin-tools-grid';
-    tools.forEach(t => {
-    const card = document.createElement('div');
-    card.className = 'admin-tool-card';
-    const imgUrl = t.thumbnail_url || '/assets/default-tool.png';
+  }
+  const grid = document.createElement("div");
+  grid.className = "admin-tools-grid";
+  tools.forEach((t) => {
+    const card = document.createElement("div");
+    card.className = "admin-tool-card";
+    const imgUrl = t.thumbnail_url || "/assets/default-tool.png";
     card.innerHTML = `
         <img src="${imgUrl}" alt="${t.title}">
         <div class="tool-title">${t.title}</div>
         <div class="tool-status">${t.status}</div>
     `;
     grid.appendChild(card);
-    });
-    container.appendChild(grid);
-    return container;
+  });
+  container.appendChild(grid);
+  return container;
 }
 
 function renderAccessDenied() {
-    const container = document.createElement('div');
-    container.className = 'access-denied';
-    container.innerHTML = `
+  const container = document.createElement("div");
+  container.className = "access-denied";
+  container.innerHTML = `
     <i class="fas fa-ban"></i>
     <h2>Accès refusé</h2>
     <p>Vous n'avez pas les permissions nécessaires pour accéder à cette section. Seuls les administrateurs peuvent accéder au panel admin.</p>
@@ -844,359 +942,424 @@ function renderAccessDenied() {
         <i class="fas fa-home"></i> Retour à l'accueil
     </a>
     `;
-    return container;
+  return container;
 }
 
 async function openUserModal(userId) {
-    currentUserId = userId;
-    const modal = document.getElementById('user-modal');
-    modal.classList.add('active');
-    
-    document.getElementById('modal-user-name').textContent = 'Chargement...';
-    document.getElementById('modal-avatar').src = '/assets/account.png';
-    
-    const data = await fetchUserDetails(userId);
-    if (!data || !data.user) {
-    console.error('Failed to load user details');
-    return;
-    }
-    const user = data.user;
-    
-    document.getElementById('modal-user-name').textContent = user.username;
-    const verifiedIcon = document.getElementById('modal-verified');
-    if (user.is_verified) {
-    verifiedIcon.style.display = 'inline-block';
-    } else {
-    verifiedIcon.style.display = 'none';
-    }
-    document.getElementById('modal-avatar').src = user.avatar || '/assets/account.png';
+  currentUserId = userId;
+  const modal = document.getElementById("user-modal");
+  modal.classList.add("active");
 
-    const banButton = document.getElementById('ban-user');
-    if (user.status === 'Banned') {
+  document.getElementById("modal-user-name").textContent = "Chargement...";
+  document.getElementById("modal-avatar").src = "/assets/account.png";
+
+  const data = await fetchUserDetails(userId);
+  if (!data || !data.user) {
+    console.error("Failed to load user details");
+    return;
+  }
+  const user = data.user;
+
+  document.getElementById("modal-user-name").textContent = user.username;
+  const verifiedIcon = document.getElementById("modal-verified");
+  if (user.is_verified) {
+    verifiedIcon.style.display = "inline-block";
+  } else {
+    verifiedIcon.style.display = "none";
+  }
+  document.getElementById("modal-avatar").src =
+    user.avatar || "/assets/account.png";
+
+  const banButton = document.getElementById("ban-user");
+  if (user.status === "Banned") {
     banButton.innerHTML = '<i class="fas fa-undo"></i> Débannir';
-    } else {
+  } else {
     banButton.innerHTML = '<i class="fas fa-ban"></i> Bannir';
-    }
-    
-    const roleBadge = document.getElementById('modal-user-role');
-    roleBadge.textContent =
-    user.role === 'Admin' ? 'Administrateur' :
-    user.role === 'Moderator' ? 'Modérateur' : 'Utilisateur';
-    roleBadge.className =
-    `user-role ${user.role === 'Admin' ? 'role-admin' :
-    user.role === 'Moderator' ? 'role-moderator' : 'role-user'}`;
-    
-    document.getElementById('tools-count').textContent = user.toolsCount || 0;
-    document.getElementById('reports-count').textContent = user.reportsCount || 0;
-    document.getElementById('joined-date').textContent = new Date(user.createdAt).toLocaleDateString();
-    const banInfo = document.getElementById('ban-info');
-    if (user.status === 'Banned') {
-    let text = '';
+  }
+
+  const roleBadge = document.getElementById("modal-user-role");
+  roleBadge.textContent =
+    user.role === "Admin"
+      ? "Administrateur"
+      : user.role === "Moderator"
+        ? "Modérateur"
+        : "Utilisateur";
+  roleBadge.className = `user-role ${
+    user.role === "Admin"
+      ? "role-admin"
+      : user.role === "Moderator"
+        ? "role-moderator"
+        : "role-user"
+  }`;
+
+  document.getElementById("tools-count").textContent = user.toolsCount || 0;
+  document.getElementById("reports-count").textContent = user.reportsCount || 0;
+  document.getElementById("joined-date").textContent = new Date(
+    user.createdAt,
+  ).toLocaleDateString();
+  const banInfo = document.getElementById("ban-info");
+  if (user.status === "Banned") {
+    let text = "";
     let intervalId = null;
 
     function updateBanCountdown() {
-        if (user.ban_permanent) {
-    text = 'Banni définitivement';
-    banInfo.innerHTML = `<span id="ban-text">${text}</span> <button class="btn btn-warning btn-sm" id="view-ban-reason">Voir la raison du bannissement</button>`;
-    clearInterval(intervalId);
-        } else if (user.ban_until) {
-    const end = new Date(user.ban_until);
-    const now = Date.now();
-    const diff = Math.max(0, end - now);
-    if (diff <= 0) {
-        text = 'Ban terminé';
+      if (user.ban_permanent) {
+        text = "Banni définitivement";
+        banInfo.innerHTML = `<span id="ban-text">${text}</span> <button class="btn btn-warning btn-sm" id="view-ban-reason">Voir la raison du bannissement</button>`;
         clearInterval(intervalId);
-    } else {
-        const totalSeconds = Math.floor(diff / 1000);
-        const hours = Math.floor(totalSeconds / 3600);
-        const minutes = Math.floor((totalSeconds % 3600) / 60);
-        const seconds = totalSeconds % 60;
-        text = `Durée de ban restant : ${hours}h ${minutes}m ${seconds}s`;
-    }
-    banInfo.innerHTML = `<span id="ban-text">${text}</span> <button class="btn btn-warning btn-sm" id="view-ban-reason">Voir la raison du bannissement</button>`;
+      } else if (user.ban_until) {
+        const end = new Date(user.ban_until);
+        const now = Date.now();
+        const diff = Math.max(0, end - now);
+        if (diff <= 0) {
+          text = "Ban terminé";
+          clearInterval(intervalId);
+        } else {
+          const totalSeconds = Math.floor(diff / 1000);
+          const hours = Math.floor(totalSeconds / 3600);
+          const minutes = Math.floor((totalSeconds % 3600) / 60);
+          const seconds = totalSeconds % 60;
+          text = `Durée de ban restant : ${hours}h ${minutes}m ${seconds}s`;
         }
-        // Ajoute l'event listener à chaque update
-        const btn = document.getElementById('view-ban-reason');
-        if (btn) {
-    btn.onclick = async () => {
-        const res = await fetchBanInfo(userId);
-        if (res && res.ban && res.ban.reason) {
-        showToast('info', `Raison du bannissement de ${user.username} : ${res.ban.reason}`);
-        }
-    };
-        }
+        banInfo.innerHTML = `<span id="ban-text">${text}</span> <button class="btn btn-warning btn-sm" id="view-ban-reason">Voir la raison du bannissement</button>`;
+      }
+      // Ajoute l'event listener à chaque update
+      const btn = document.getElementById("view-ban-reason");
+      if (btn) {
+        btn.onclick = async () => {
+          const res = await fetchBanInfo(userId);
+          if (res && res.ban && res.ban.reason) {
+            showToast(
+              "info",
+              `Raison du bannissement de ${user.username} : ${res.ban.reason}`,
+            );
+          }
+        };
+      }
     }
 
     updateBanCountdown();
     if (!user.ban_permanent && user.ban_until) {
-        intervalId = setInterval(updateBanCountdown, 1000);
+      intervalId = setInterval(updateBanCountdown, 1000);
     }
-    banInfo.style.display = 'block';
-    } else {
-    banInfo.style.display = 'none';
-    }
-    
-    document.getElementById('username').value = user.username;
-    document.getElementById('email').value = user.email;
-    const bioField = document.getElementById('bio');
-    if (user.bio) {
+    banInfo.style.display = "block";
+  } else {
+    banInfo.style.display = "none";
+  }
+
+  document.getElementById("username").value = user.username;
+  document.getElementById("email").value = user.email;
+  const bioField = document.getElementById("bio");
+  if (user.bio) {
     bioField.value = user.bio;
-    bioField.placeholder = '';
-    } else {
-    bioField.value = '';
-    bioField.placeholder = 'Aucune bio';
-    }
-    document.getElementById('user-role').value = user.role || 'User';
-    document.getElementById('account-status').value = user.status || 'Good';
+    bioField.placeholder = "";
+  } else {
+    bioField.value = "";
+    bioField.placeholder = "Aucune bio";
+  }
+  document.getElementById("user-role").value = user.role || "User";
+  document.getElementById("account-status").value = user.status || "Good";
 
-    const activityTab = document.getElementById('activity-tab');
-    activityTab.innerHTML = '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
-    const activityData = await fetchUserActivity(userId, 1);
-    totalActivity = activityData.total || 0;
-    currentActivityPage = 1;
-    activityTab.innerHTML = '';
-    activityTab.appendChild(renderUserActivity(activityData.logs || [], 1, totalActivity));
+  const activityTab = document.getElementById("activity-tab");
+  activityTab.innerHTML =
+    '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
+  const activityData = await fetchUserActivity(userId, 1);
+  totalActivity = activityData.total || 0;
+  currentActivityPage = 1;
+  activityTab.innerHTML = "";
+  activityTab.appendChild(
+    renderUserActivity(activityData.logs || [], 1, totalActivity),
+  );
 
-    const toolsTab = document.getElementById('tools-tab');
-    toolsTab.innerHTML = '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
-    const toolsData = await fetchUserTools(userId);
-    toolsTab.innerHTML = '';
-    toolsTab.appendChild(renderUserTools(toolsData.tools || []));
+  const toolsTab = document.getElementById("tools-tab");
+  toolsTab.innerHTML =
+    '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
+  const toolsData = await fetchUserTools(userId);
+  toolsTab.innerHTML = "";
+  toolsTab.appendChild(renderUserTools(toolsData.tools || []));
 }
 
 function closeUserModal() {
-    document.getElementById('user-modal').classList.remove('active');
-    currentUserId = null;
+  document.getElementById("user-modal").classList.remove("active");
+  currentUserId = null;
 }
 
 function setupTabs() {
-    document.querySelectorAll('.user-tab').forEach(tab => {
-    tab.addEventListener('click', async () => {
-        document.querySelectorAll('.user-tab').forEach(t => t.classList.remove('active'));
-        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-        
-        tab.classList.add('active');
-        const tabId = tab.getAttribute('data-tab');
-        document.getElementById(`${tabId}-tab`).classList.add('active');
-        if (tabId === 'activity') {
+  document.querySelectorAll(".user-tab").forEach((tab) => {
+    tab.addEventListener("click", async () => {
+      document
+        .querySelectorAll(".user-tab")
+        .forEach((t) => t.classList.remove("active"));
+      document
+        .querySelectorAll(".tab-content")
+        .forEach((c) => c.classList.remove("active"));
+
+      tab.classList.add("active");
+      const tabId = tab.getAttribute("data-tab");
+      document.getElementById(`${tabId}-tab`).classList.add("active");
+      if (tabId === "activity") {
         loadActivityPage(currentActivityPage);
-        } else if (tabId === 'tools') {
+      } else if (tabId === "tools") {
         if (!currentUserId) return;
-        const toolsTab = document.getElementById('tools-tab');
-        toolsTab.innerHTML = '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
+        const toolsTab = document.getElementById("tools-tab");
+        toolsTab.innerHTML =
+          '<div class="skeleton" style="height: 300px; border-radius: 8px;"></div>';
         const toolsData = await fetchUserTools(currentUserId);
-        toolsTab.innerHTML = '';
+        toolsTab.innerHTML = "";
         toolsTab.appendChild(renderUserTools(toolsData.tools || []));
-        }
+      }
     });
-    });
+  });
 }
 
 async function loadStats() {
-    const stats = await fetchStats();
-    if (stats) {
+  const stats = await fetchStats();
+  if (stats) {
     const statsElement = renderStats(stats);
     adminContent.appendChild(statsElement);
-    }
+  }
 }
 
-async function loadUsers(search = '', page = 1) {
-    const existing = document.getElementById(SECTION_IDS.users);
-    if (existing) existing.remove();
+async function loadUsers(search = "", page = 1) {
+  const existing = document.getElementById(SECTION_IDS.users);
+  if (existing) existing.remove();
 
-    const placeholder = renderUsersTable([]);
-    placeholder.id = SECTION_IDS.users;
-    adminContent.appendChild(placeholder);
-    showLoadingSkeleton('users');
+  const placeholder = renderUsersTable([]);
+  placeholder.id = SECTION_IDS.users;
+  adminContent.appendChild(placeholder);
+  showLoadingSkeleton("users");
 
-    const { users, total } = await fetchUsers(search, page);
-    const usersElement = renderUsersTable(users, page, total);
-    usersElement.id = SECTION_IDS.users;
+  const { users, total } = await fetchUsers(search, page);
+  const usersElement = renderUsersTable(users, page, total);
+  usersElement.id = SECTION_IDS.users;
 
-    if (!document.querySelector('.stats-cards')) {
+  if (!document.querySelector(".stats-cards")) {
     await loadStats();
-    }
+  }
 
-    placeholder.replaceWith(usersElement);
+  placeholder.replaceWith(usersElement);
 }
 
 async function loadSystemLogs(page = 1) {
-    const existing = document.getElementById(SECTION_IDS.logs);
-    if (existing) existing.remove();
+  const existing = document.getElementById(SECTION_IDS.logs);
+  if (existing) existing.remove();
 
-    const placeholder = renderSystemLogs([]);
-    placeholder.id = SECTION_IDS.logs;
-    adminContent.appendChild(placeholder);
-    showLoadingSkeleton('logs');
+  const placeholder = renderSystemLogs([]);
+  placeholder.id = SECTION_IDS.logs;
+  adminContent.appendChild(placeholder);
+  showLoadingSkeleton("logs");
 
-    const { logs, total } = await fetchSystemLogs(page);
-    const logsElement = renderSystemLogs(logs, page, total);
-    logsElement.id = SECTION_IDS.logs;
+  const { logs, total } = await fetchSystemLogs(page);
+  const logsElement = renderSystemLogs(logs, page, total);
+  logsElement.id = SECTION_IDS.logs;
 
-    if (!document.querySelector('.stats-cards')) {
+  if (!document.querySelector(".stats-cards")) {
     await loadStats();
-    }
-    if (!document.getElementById(SECTION_IDS.users)) {
+  }
+  if (!document.getElementById(SECTION_IDS.users)) {
     await loadUsers();
-    }
+  }
 
-    placeholder.replaceWith(logsElement);
+  placeholder.replaceWith(logsElement);
 }
 
 async function loadAppeals(page = 1) {
-    const existing = document.getElementById(SECTION_IDS.appeals);
-    if (existing) existing.remove();
+  const existing = document.getElementById(SECTION_IDS.appeals);
+  if (existing) existing.remove();
 
-    const placeholder = renderAppealsTable([]);
-    placeholder.id = SECTION_IDS.appeals;
-    adminContent.appendChild(placeholder);
+  const placeholder = renderAppealsTable([]);
+  placeholder.id = SECTION_IDS.appeals;
+  adminContent.appendChild(placeholder);
 
-    const { appeals, total } = await fetchAppeals(page);
-    const element = renderAppealsTable(appeals, page, total);
-    element.id = SECTION_IDS.appeals;
-    placeholder.replaceWith(element);
+  const { appeals, total } = await fetchAppeals(page);
+  const element = renderAppealsTable(appeals, page, total);
+  element.id = SECTION_IDS.appeals;
+  placeholder.replaceWith(element);
 }
 
 function navigate(path) {
-    history.pushState({}, '', path);
-    if (path.endsWith('/logs')) {
-        loadSystemLogs();
-    } else if (path.endsWith('/appeals')) {
-        loadAppeals();
-    } else {
-        loadUsers();
-    }
+  history.pushState({}, "", path);
+  if (path.endsWith("/logs")) {
+    loadSystemLogs();
+  } else if (path.endsWith("/appeals")) {
+    loadAppeals();
+  } else {
+    loadUsers();
+  }
 }
 
-window.addEventListener('popstate', () => {
-    if (location.pathname.endsWith('/logs')) {
-        loadSystemLogs();
-    } else if (location.pathname.endsWith('/appeals')) {
-        loadAppeals();
-    } else {
-        loadUsers();
-    }
+window.addEventListener("popstate", () => {
+  if (location.pathname.endsWith("/logs")) {
+    loadSystemLogs();
+  } else if (location.pathname.endsWith("/appeals")) {
+    loadAppeals();
+  } else {
+    loadUsers();
+  }
 });
 
 async function initAdminPanel() {
-    const isAdmin = await checkAdminPermissions();
-    if (!isAdmin) {
-    preloader.style.display = 'none';
+  const isAdmin = await checkAdminPermissions();
+  if (!isAdmin) {
+    preloader.style.display = "none";
     adminContent.appendChild(renderAccessDenied());
     return;
-    }
-    
-    await loadStats();
-    await loadUsers();
-    await loadSystemLogs();
-    await loadAppeals();
-    
+  }
+
+  await loadStats();
+  await loadUsers();
+  await loadSystemLogs();
+  await loadAppeals();
+
+  setTimeout(() => {
+    preloader.style.opacity = "0";
     setTimeout(() => {
-    preloader.style.opacity = '0';
-    setTimeout(() => {
-        preloader.style.display = 'none';
+      preloader.style.display = "none";
     }, 500);
-    }, 500);
-    
-    setupTabs();
+  }, 500);
 
-    document.querySelectorAll('.sidebar-item[data-path]').forEach(link => {
-    link.addEventListener('click', e => {
-        e.preventDefault();
-        document.querySelectorAll('.sidebar-item').forEach(a => a.classList.remove('active'));
-        link.classList.add('active');
-        navigate(link.getAttribute('data-path'));
+  setupTabs();
+
+  document.querySelectorAll(".sidebar-item[data-path]").forEach((link) => {
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      document
+        .querySelectorAll(".sidebar-item")
+        .forEach((a) => a.classList.remove("active"));
+      link.classList.add("active");
+      navigate(link.getAttribute("data-path"));
     });
-    });
-    
-    document.getElementById('close-modal').addEventListener('click', closeUserModal);
-    document.getElementById('cancel-changes').addEventListener('click', closeUserModal);
-    
-    document.getElementById('save-changes').addEventListener('click', async () => {
-    if (!currentUserId) return;
+  });
 
-    const userData = {
-        username: document.getElementById('username').value,
-        email: document.getElementById('email').value,
-        bio: document.getElementById('bio').value,
-        role: document.getElementById('user-role').value,
-        status: document.getElementById('account-status').value
-    };
+  document
+    .getElementById("close-modal")
+    .addEventListener("click", closeUserModal);
+  document
+    .getElementById("cancel-changes")
+    .addEventListener("click", closeUserModal);
 
-    const result = await updateUser(currentUserId, userData);
-    if (result) {
+  document
+    .getElementById("save-changes")
+    .addEventListener("click", async () => {
+      if (!currentUserId) return;
+
+      const userData = {
+        username: document.getElementById("username").value,
+        email: document.getElementById("email").value,
+        bio: document.getElementById("bio").value,
+        role: document.getElementById("user-role").value,
+        status: document.getElementById("account-status").value,
+      };
+
+      const result = await updateUser(currentUserId, userData);
+      if (result) {
         closeUserModal();
         await loadUsers();
-    }
+      }
     });
-    
-    const banModal = document.getElementById('ban-modal');
-    const closeBanModal = document.getElementById('close-ban-modal');
-    const cancelBan = document.getElementById('cancel-ban');
-    const confirmBan = document.getElementById('confirm-ban');
-    const banReasonInput = document.getElementById('ban-reason');
-    const unbanText = document.getElementById('unban-text');
-    const banReasonGroup = document.querySelector('.ban-reason-group');
 
-    function openBanModal(isUnban) {
-    banModal.classList.add('active');
+  const banModal = document.getElementById("ban-modal");
+  const closeBanModal = document.getElementById("close-ban-modal");
+  const cancelBan = document.getElementById("cancel-ban");
+  const confirmBan = document.getElementById("confirm-ban");
+  const banReasonInput = document.getElementById("ban-reason");
+  const unbanText = document.getElementById("unban-text");
+  const banReasonGroup = document.querySelector(".ban-reason-group");
+
+  const appealModal = document.getElementById("appeal-modal");
+  const closeAppealModal = document.getElementById("close-appeal-modal");
+  const cancelAppeal = document.getElementById("cancel-appeal");
+  const confirmAppeal = document.getElementById("confirm-appeal");
+  const appealMsg = document.getElementById("appeal-message");
+  let currentAppealId = null;
+  let currentAppealApprove = false;
+
+  function openAppealModal(id, approve, page) {
+    currentAppealId = id;
+    currentAppealApprove = approve;
+    confirmAppeal.dataset.page = page;
+    appealMsg.value = "";
+    appealModal.classList.add("active");
+  }
+
+  function closeAppeal() {
+    appealModal.classList.remove("active");
+    appealMsg.value = "";
+  }
+
+  closeAppealModal.addEventListener("click", closeAppeal);
+  cancelAppeal.addEventListener("click", closeAppeal);
+  confirmAppeal.addEventListener("click", async () => {
+    const msg = appealMsg.value.trim();
+    const page = parseInt(confirmAppeal.dataset.page);
+    const ok = await reviewAppeal(currentAppealId, currentAppealApprove, msg);
+    if (ok) {
+      closeAppeal();
+      loadAppeals(page);
+    }
+  });
+
+  function openBanModal(isUnban) {
+    banModal.classList.add("active");
     if (isUnban) {
-        document.getElementById('ban-modal-title').textContent = 'Débannir l\'utilisateur';
-        banReasonGroup.style.display = 'none';
-        unbanText.classList.remove('hidden');
-        confirmBan.textContent = 'Débannir';
+      document.getElementById("ban-modal-title").textContent =
+        "Débannir l'utilisateur";
+      banReasonGroup.style.display = "none";
+      unbanText.classList.remove("hidden");
+      confirmBan.textContent = "Débannir";
     } else {
-        document.getElementById('ban-modal-title').textContent = 'Bannir l\'utilisateur';
-        banReasonGroup.style.display = 'block';
-        unbanText.classList.add('hidden');
-        confirmBan.textContent = 'Bannir';
-        banReasonInput.value = '';
+      document.getElementById("ban-modal-title").textContent =
+        "Bannir l'utilisateur";
+      banReasonGroup.style.display = "block";
+      unbanText.classList.add("hidden");
+      confirmBan.textContent = "Bannir";
+      banReasonInput.value = "";
     }
-    }
+  }
 
-    function closeBan() {
-    banModal.classList.remove('active');
-    banReasonInput.value = '';
-    document.getElementById('ban-duration').value = '24';
-    }
+  function closeBan() {
+    banModal.classList.remove("active");
+    banReasonInput.value = "";
+    document.getElementById("ban-duration").value = "24";
+  }
 
-    closeBanModal.addEventListener('click', closeBan);
-    cancelBan.addEventListener('click', closeBan);
+  closeBanModal.addEventListener("click", closeBan);
+  cancelBan.addEventListener("click", closeBan);
 
-    document.getElementById('ban-user').addEventListener('click', () => {
+  document.getElementById("ban-user").addEventListener("click", () => {
     if (!currentUserId) return;
-    const status = document.getElementById('account-status').value;
-    openBanModal(status === 'Banned');
-    });
+    const status = document.getElementById("account-status").value;
+    openBanModal(status === "Banned");
+  });
 
-    confirmBan.addEventListener('click', async () => {
+  confirmBan.addEventListener("click", async () => {
     if (!currentUserId) return;
-    const status = document.getElementById('account-status').value;
+    const status = document.getElementById("account-status").value;
     confirmBan.disabled = true;
-    const spinner = document.createElement('span');
-    spinner.className = 'spinner spinner-btn';
+    const spinner = document.createElement("span");
+    spinner.className = "spinner spinner-btn";
     confirmBan.prepend(spinner);
     let result = null;
-    if (status === 'Banned') {
-        result = await unbanUser(currentUserId);
+    if (status === "Banned") {
+      result = await unbanUser(currentUserId);
     } else {
-        const reason = banReasonInput.value.trim();
-        if (!reason) {
-        showToast('error', 'Vous devez préciser une raison');
+      const reason = banReasonInput.value.trim();
+      if (!reason) {
+        showToast("error", "Vous devez préciser une raison");
         confirmBan.disabled = false;
         spinner.remove();
         return;
-        }
-        result = await banUser(currentUserId, reason);
+      }
+      result = await banUser(currentUserId, reason);
     }
     if (result) {
-        closeBan();
-        closeUserModal();
-        await loadUsers();
+      closeBan();
+      closeUserModal();
+      await loadUsers();
     }
     confirmBan.disabled = false;
     spinner.remove();
-    });
+  });
 }
 
-document.addEventListener('DOMContentLoaded', initAdminPanel);
+document.addEventListener("DOMContentLoaded", initAdminPanel);


### PR DESCRIPTION
## Summary
- add immediate SendEmail helper
- include appeal ID in notification emails
- enrich admin contestation handling with modal and icons
- improve account sanctions UX with random icons and modal appeal form
- document updates in README and private articles

## Testing
- `go vet ./...`
- `npx prettier -w frontend/src/JS/account/index.js frontend/account/index.html frontend/src/CSS/account/index.css`
- `npx prettier -w README.md api/utils/privates_articles.json`


------
https://chatgpt.com/codex/tasks/task_e_686fce5ff26c8320abd4a01bf82c1adf