### PR TITLE
Add MIT license & bilingual docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2025 Gabriel B. (gabrielb0x)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # 🚀 **Tool Center**
 
+> **English ⇩** — [Version française](#-version-francaise)
+
 ![Tool Center Banner](./frontend/public/assets/Banniere-TC.png)
 
 > **Tool Center** is the flagship project of **[@gabrielb0x](https://github.com/gabrielb0x)**.
 > A mix of **code**, **passion** and **usefulness** made for people who want quality tools.
+
+
+## About this project
+
+This repository is open-source under the [MIT License](LICENSE). It started as a personal learning project for Gabriel B., a 17-year-old high-school student in the French CIEL track. The code heavily relies on AI-assisted generation but was a great way to gain experience. You are welcome to study it, improve it and adapt it for your own needs.
 
 ---
 
@@ -153,4 +160,34 @@ Want to contribute or report a bug?
 
 ---
 
-## **© Gabriel B., 2024-2025 — All rights reserved.**
+## **© 2024-2025 Gabriel B. (gabrielb0x) — Released under the MIT License.**
+
+---
+
+## 🇫🇷 Version française
+
+**Tool Center** est un projet open source sous licence [MIT](LICENSE). Il a été réalisé principalement pour apprendre et expérimenter. En tant qu'étudiant de 17 ans en filière professionnelle CIEL, j'ai utilisé l'intelligence artificielle pour accélérer le développement, mais j'ai beaucoup progressé grâce à ce projet. Vous êtes libres de l'étudier, de l'améliorer et de le partager.
+
+### Démarrage rapide
+
+1. Clonez le dépôt :
+   ```bash
+   git clone https://github.com/gabrielb0x/tool-center.git
+   ```
+2. Copiez `api/example config.json` vers `api/config.json` et ajustez les paramètres (base de données, SMTP, etc.).
+3. Installez les dépendances Go :
+   ```bash
+   cd api && go mod tidy
+   ```
+4. Lancez l'API :
+   ```bash
+   go run main.go
+   ```
+5. Construisez le frontend :
+   ```bash
+   cd ../frontend
+   npm install
+   npm run build
+   ```
+
+Pour plus de détails, reportez‑vous aux sections précédentes de ce README.


### PR DESCRIPTION
## Summary
- add MIT License file acknowledging Gabriel B. ownership
- document the open source nature and learning purpose in README
- provide bilingual README sections for English and French readers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fdf366b8883209142b4f02f20cecd